### PR TITLE
Transform added tasks into GPT-generated haiku

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project started as a minimal Vite + React setup styled with Tailwind CSS.
 It now includes a simple to-do list where you can add tasks and mark them as completed.
 An ASCII art title with a blinking terminal-style cursor is displayed above the list.
 
+When a task is added it is sent to the OpenAI API and rewritten as an ambiguous haiku
+before being stored.
+
 ## Development
 
 ```bash
@@ -11,3 +14,6 @@ cd qtodo-gptchain
 npm install
 npm run dev
 ```
+
+Set a `VITE_OPENAI_API_KEY` environment variable with an OpenAI API key to enable
+haiku generation.

--- a/qtodo-gptchain/src/App.jsx
+++ b/qtodo-gptchain/src/App.jsx
@@ -8,6 +8,31 @@ const fetchQuantumRandom = async (length) => {
   return data.data
 }
 
+const generateHaiku = async (task) => {
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: 'Turn tasks into ambiguous haiku.' },
+          { role: 'user', content: `Task: ${task}` },
+        ],
+      }),
+    })
+    const data = await res.json()
+    const content = data?.choices?.[0]?.message?.content
+    return content?.trim() || task
+  } catch (err) {
+    console.error('OpenAI request failed', err)
+    return task
+  }
+}
+
 function App() {
   const [taskText, setTaskText] = useState('')
   const [tasks, setTasks] = useState([])
@@ -43,10 +68,11 @@ function App() {
     }
   }, [tasks])
 
-  const addTask = () => {
+  const addTask = async () => {
     const text = taskText.trim()
     if (text) {
-      setTasks([...tasks, { text, completed: false }])
+      const haiku = await generateHaiku(text)
+      setTasks([...tasks, { text: haiku, completed: false }])
       setTaskText('')
     }
   }


### PR DESCRIPTION
## Summary
- send new task text to OpenAI chat completions and save the returned ambiguous haiku
- document haiku feature and required `VITE_OPENAI_API_KEY`

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9d3261cd48322a4e5ef752aa32db8