### PR TITLE
Document absurd todo list features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # qtodo-gptchain
 
-This project started as a minimal Vite + React setup styled with Tailwind CSS.
-It now includes a simple to-do list where you can add tasks and mark them as completed.
-An ASCII art title with a blinking terminal-style cursor is displayed above the list.
+Because building a normal to-do app would have been too easy, this project leans hard
+into unnecessary complexity.
 
-When a task is added it is sent to the OpenAI API and rewritten as an ambiguous haiku
-before being stored.
+## Features you'll brag about (to no one)
+
+- **Quantum-powered procrastination**: tasks reshuffle once a day using *actual* quantum
+  randomness. Your chores literally move at the whims of physics.
+- **Haiku-based clarity**: every task you add is politely mangled into an ambiguous
+  haiku by the OpenAI API. Because nothing says "productivity" like decoding your own
+  poetry.
+- **Blinking ASCII art**: a retro banner with a fake terminal cursor just to prove we
+  spent time on the wrong things.
+- **LocalStorage persistence**: your poetic chores survive page refreshes, lucky you.
+- **React + Vite + Tailwind**: all the modern web tooling you never needed to manage a
+  handful of checkboxes.
 
 ## Development
 
@@ -15,5 +24,6 @@ npm install
 npm run dev
 ```
 
-Set a `VITE_OPENAI_API_KEY` environment variable with an OpenAI API key to enable
-haiku generation.
+Set a `VITE_OPENAI_API_KEY` environment variable with an OpenAI API key if you actually
+want the AI to butcher your tasks into haiku. Without it, the app grudgingly keeps your
+original text.

--- a/qtodo-gptchain/README.md
+++ b/qtodo-gptchain/README.md
@@ -1,12 +1,22 @@
-# React + Vite
+# qtodo-gptchain
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Yes, the source for the world's most over-engineered to-do list lives here.
+Because nothing says "stay organized" like React, Vite, Tailwind and a mild
+identity crisis.
 
-Currently, two official plugins are available:
+## Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Tasks are lovingly transmogrified into enigmatic haiku by the OpenAI API.
+- Daily quantum random shuffling keeps you guessing which chore comes next.
+- A blinking ASCII banner to prove we care more about aesthetics than usefulness.
+- LocalStorage persistence so your confusion survives every refresh.
 
-## Expanding the ESLint configuration
+## Development
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+npm install
+npm run dev
+```
+
+Set `VITE_OPENAI_API_KEY` in your environment if you actually want the AI to
+rewrite your tasks. Otherwise, enjoy plain text like it's 1999.


### PR DESCRIPTION
## Summary
- Rewrite README with sarcastic rundown of quantum shuffling, haiku generation and other over-engineered flair
- Replace Vite template README in app directory with equally snarky instructions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9d4188ad08322ab5fb50abf1cec76