### PR TITLE
Add OpenTimestamps support for expired tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This is the todo list app absolutely no one needs, yet here we are.
   ambiguously poetic haiku. Understanding the checklist is half the battle.
 - **Task expiration** – give a task a deadline; once it passes, the task becomes
   undeletable, a haunting reminder of your unfinished ambitions.
+- **OpenTimestamps proofs** – expired tasks can be hashed in-browser and timestamped
+  without ever leaking their contents. Proofs are created, verified and upgraded via a
+  tiny FastAPI server.
 - **Blinking ASCII art** – because a todo app without terminal nostalgia is hardly
   worth opening.
 - **LocalStorage persistence** – your list survives refreshes and browser restarts so
@@ -27,6 +30,14 @@ The app now ships with Vitest and React Testing Library.
 ```bash
 cd qtodo-gptchain
 npm test
+```
+
+### OpenTimestamps Server
+
+```bash
+cd ots-server
+pip install -r requirements.txt
+uvicorn main:app --reload
 ```
 
 ## Development

--- a/ots-server/main.py
+++ b/ots-server/main.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import base64
+from opentimestamps.client import Client
+
+app = FastAPI()
+client = Client()
+
+class HashReq(BaseModel):
+    hash: str
+
+class VerifyReq(BaseModel):
+    hash: str
+    proof: str
+
+class UpgradeReq(BaseModel):
+    proof: str
+
+@app.post('/ots/create')
+def create(req: HashReq):
+    proof = client.create(bytes.fromhex(req.hash))
+    return {'proof': base64.b64encode(proof).decode()}
+
+@app.post('/ots/verify')
+def verify(req: VerifyReq):
+    proof = base64.b64decode(req.proof)
+    ok = client.verify(bytes.fromhex(req.hash), proof)
+    return {'verified': ok}
+
+@app.post('/ots/upgrade')
+def upgrade(req: UpgradeReq):
+    proof = base64.b64decode(req.proof)
+    upgraded = client.upgrade(proof)
+    return {'proof': base64.b64encode(upgraded).decode()}

--- a/ots-server/requirements.txt
+++ b/ots-server/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+opentimestamps-client

--- a/qtodo-gptchain/README.md
+++ b/qtodo-gptchain/README.md
@@ -12,12 +12,23 @@ identity crisis.
 - LocalStorage persistence so your confusion survives every refresh.
 - Assign expiry dates to tasks; once a task's time is up, it's immortal and
   can no longer be deleted.
+- Expired tasks can be timestamped with OpenTimestamps. The app hashes the task locally
+  and sends only the hash to a small FastAPI helper for proof creation, verification and
+  upgrades.
 
 ## Development
 
 ```bash
 npm install
 npm run dev
+```
+
+To use OpenTimestamps, run the server from the repository root:
+
+```bash
+cd ../ots-server
+pip install -r requirements.txt
+uvicorn main:app --reload
 ```
 
 Set `VITE_OPENAI_API_KEY` in your environment if you actually want the AI to

--- a/qtodo-gptchain/src/App.test.jsx
+++ b/qtodo-gptchain/src/App.test.jsx
@@ -13,7 +13,19 @@ afterEach(() => {
 
 describe('App', () => {
   it('loads tasks from localStorage', () => {
-    const tasks = [{ text: 'existing', completed: false, expires: Date.now() + 1000 }]
+    const tasks = [
+      {
+        title: 'existing',
+        note: '',
+        created_at: Date.now(),
+        expired_at: Date.now() + 1000,
+        completed: false,
+        status: 'active',
+        user_id: 1,
+        version: 1,
+        otsMeta: {},
+      },
+    ]
     localStorage.setItem('tasks', JSON.stringify(tasks))
     render(<App />)
     expect(screen.getByText('existing')).toBeInTheDocument()
@@ -42,7 +54,19 @@ describe('App', () => {
   })
 
   it('toggles task completion', () => {
-    const tasks = [{ text: 'finish report', completed: false, expires: Date.now() + 1000 }]
+    const tasks = [
+      {
+        title: 'finish report',
+        note: '',
+        created_at: Date.now(),
+        expired_at: Date.now() + 1000,
+        completed: false,
+        status: 'active',
+        user_id: 1,
+        version: 1,
+        otsMeta: {},
+      },
+    ]
     localStorage.setItem('tasks', JSON.stringify(tasks))
     render(<App />)
     const checkbox = screen.getByRole('checkbox')
@@ -55,8 +79,28 @@ describe('App', () => {
       json: () => Promise.resolve({ data: [0, 1] }),
     })
     const tasks = [
-      { text: 'old', completed: false, expires: Date.now() - 1000 },
-      { text: 'new', completed: false, expires: Date.now() + 1000 },
+      {
+        title: 'old',
+        note: '',
+        created_at: Date.now() - 2000,
+        expired_at: Date.now() - 1000,
+        completed: false,
+        status: 'expired',
+        user_id: 1,
+        version: 1,
+        otsMeta: { hash: 'deadbeef' },
+      },
+      {
+        title: 'new',
+        note: '',
+        created_at: Date.now(),
+        expired_at: Date.now() + 1000,
+        completed: false,
+        status: 'active',
+        user_id: 1,
+        version: 1,
+        otsMeta: {},
+      },
     ]
     localStorage.setItem('tasks', JSON.stringify(tasks))
     render(<App />)

--- a/qtodo-gptchain/src/ots.test.js
+++ b/qtodo-gptchain/src/ots.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { canonicalizeTask, sha256Hex } from './utils/ots'
+
+describe('ots utils', () => {
+  it('canonicalizes task data', () => {
+    const task = { title: 'test', note: '', created_at: 1, expired_at: 2, user_id: 1 }
+    const canonical = canonicalizeTask(task)
+    expect(canonical).toBe('{"title":"test","note":"","created_at":1,"expired_at":2,"status":"expired","user_id":1,"version":1}')
+  })
+
+  it('hashes canonical data', async () => {
+    const canonical = '{"title":"test","note":"","created_at":1,"expired_at":2,"status":"expired","user_id":1,"version":1}'
+    const hash = await sha256Hex(canonical)
+    expect(hash).toBe('a32b116286a5cc7fe120b24e9f81f4edc199a1aa1b29ea16bceea1ab88f09599')
+  })
+})

--- a/qtodo-gptchain/src/utils/ots.js
+++ b/qtodo-gptchain/src/utils/ots.js
@@ -1,0 +1,20 @@
+export function canonicalizeTask(task) {
+  const obj = {
+    title: task.title,
+    note: task.note ?? '',
+    created_at: task.created_at,
+    expired_at: task.expired_at,
+    status: 'expired',
+    user_id: task.user_id ?? 1,
+    version: 1,
+  }
+  return JSON.stringify(obj)
+}
+
+export async function sha256Hex(str) {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(str)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+}


### PR DESCRIPTION
## Summary
- Canonicalize expired tasks and hash them client-side before interacting with OpenTimestamps.
- Provide FastAPI helper server for creating, verifying, and upgrading OTS proofs.
- Extend UI with proof management buttons and store hash/proof metadata in LocalStorage.
- Add unit tests for canonicalization and hashing.

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b9dd5150888322aeadf1f39b29fa2f