### PR TITLE
feat: skip haiku call without api key

### DIFF
--- a/qtodo-gptchain/src/App.jsx
+++ b/qtodo-gptchain/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { canonicalizeTask, sha256Hex } from './utils/ots'
 
+// Because using a normal pseudo-RNG just isn't pretentious enough.
 const fetchQuantumRandom = async (length) => {
   const res = await fetch(
     `https://qrng.anu.edu.au/API/jsonI.php?length=${length}&type=uint8`,
@@ -9,13 +10,16 @@ const fetchQuantumRandom = async (length) => {
   return data.data
 }
 
+// Beg the AI for a haiku; if we can't afford the API key, just echo back the task.
 const generateHaiku = async (task) => {
+  const key = import.meta.env.VITE_OPENAI_API_KEY
+  if (!key) return task
   try {
     const res = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+        Authorization: `Bearer ${key}`,
       },
       body: JSON.stringify({
         model: 'gpt-4o-mini',

--- a/qtodo-gptchain/src/App.test.jsx
+++ b/qtodo-gptchain/src/App.test.jsx
@@ -32,6 +32,8 @@ describe('App', () => {
   })
 
   it('adds tasks rendered as haiku', async () => {
+    // Provide a bogus API key so generateHaiku thinks it's rich.
+    import.meta.env.VITE_OPENAI_API_KEY = 'test'
     vi.spyOn(global, 'fetch').mockResolvedValue({
       json: () =>
         Promise.resolve({

--- a/qtodo-gptchain/src/utils/ots.js
+++ b/qtodo-gptchain/src/utils/ots.js
@@ -1,3 +1,4 @@
+// Flatten a task into a JSON string so cryptographic hashes can judge us fairly.
 export function canonicalizeTask(task) {
   const obj = {
     title: task.title,
@@ -11,6 +12,7 @@ export function canonicalizeTask(task) {
   return JSON.stringify(obj)
 }
 
+// Compute SHA-256 because apparently "MD5" doesn't scare auditors anymore.
 export async function sha256Hex(str) {
   const encoder = new TextEncoder()
   const data = encoder.encode(str)


### PR DESCRIPTION
## Summary
- avoid hitting OpenAI when the API key is missing
- document ots helpers with aggressively sarcastic commentary
- test haiku rendering with a mocked API key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e510679c83229c0a7f1a9bf70d3b