### PR TITLE
feat: add self destruct countdown

### DIFF
--- a/qtodo-gptchain/src/App.test.jsx
+++ b/qtodo-gptchain/src/App.test.jsx
@@ -113,4 +113,38 @@ describe('App', () => {
     fireEvent.click(deleteFresh)
     expect(screen.queryByText('new')).not.toBeInTheDocument()
   })
+
+  it('self destruct spares expired tasks', async () => {
+    const tasks = [
+      {
+        title: 'old',
+        note: '',
+        created_at: Date.now() - 2000,
+        expired_at: Date.now() - 1000,
+        completed: false,
+        status: 'expired',
+        user_id: 1,
+        version: 1,
+        otsMeta: { hash: 'deadbeef' },
+      },
+      {
+        title: 'new',
+        note: '',
+        created_at: Date.now(),
+        expired_at: Date.now() + 1000,
+        completed: false,
+        status: 'active',
+        user_id: 1,
+        version: 1,
+        otsMeta: {},
+      },
+    ]
+    localStorage.setItem('tasks', JSON.stringify(tasks))
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: /self destruct/i }))
+    await screen.findByText(/anticlimax achieved/i, {}, { timeout: 15000 })
+    expect(screen.queryByText('new')).not.toBeInTheDocument()
+    expect(screen.getByText('old')).toBeInTheDocument()
+    expect(JSON.parse(localStorage.getItem('tasks')).length).toBe(1)
+  }, 20000)
 })


### PR DESCRIPTION
## Summary
- add optional self destruct mode with an ASCII arming banner and countdown
- gradually erase active tasks while leaving expired items and proofs intact
- cover self destruct flow with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e77a42188322be707e14c8d53de4