### PR TITLE
Add verbose comments, extra tests, and sarcastic docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,16 @@ This is the todo list app absolutely no one needs, yet here we are.
 ### Testing
 
 The app now ships with Vitest and React Testing Library.
+Because nothing says "rock-solid engineering" like watching tiny green checkmarks
+tell you that hashing strings still works in 2025.
 
 ```bash
 cd qtodo-gptchain
 npm test
 ```
+
+If those tests pass, feel free to frame the output and mail it to your future self
+as proof you once had things under control.
 
 ### OpenTimestamps Server
 

--- a/qtodo-gptchain/README.md
+++ b/qtodo-gptchain/README.md
@@ -18,6 +18,16 @@ identity crisis.
 - Should that fail to satisfy your craving for futility, an optional button flings the
   hash at a Base Sepolia contract which promptly forgets it in an event log.
 
+## Tests
+
+Because we apparently don't trust ourselves, there's a test suite.
+
+```bash
+npm test
+```
+
+If the results aren't a pristine field of green, feel free to blame cosmic rays.
+
 ## Development
 
 ```bash

--- a/qtodo-gptchain/src/App.jsx
+++ b/qtodo-gptchain/src/App.jsx
@@ -3,18 +3,24 @@ import { canonicalizeTask, sha256Hex } from './utils/ots'
 
 // Because using a normal pseudo-RNG just isn't pretentious enough.
 const fetchQuantumRandom = async (length) => {
+  // Make a totally reasonable network request to a quantum number generator
+  // because using Math.random() would obviously destroy the fabric of reality.
   const res = await fetch(
     `https://qrng.anu.edu.au/API/jsonI.php?length=${length}&type=uint8`,
   )
+  // Parse the response, pretending we're not terrified of what the universe chose.
   const data = await res.json()
+  // Return the array of numbers that will determine our fate for the day.
   return data.data
 }
 
 // Beg the AI for a haiku; if we can't afford the API key, just echo back the task.
 const generateHaiku = async (task) => {
+  // Grab the OpenAI key from the environment, or give up immediately if we live in poverty.
   const key = import.meta.env.VITE_OPENAI_API_KEY
   if (!key) return task
   try {
+    // Politely ask a hyper-advanced language model to turn our grocery list into poetry.
     const res = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -29,10 +35,13 @@ const generateHaiku = async (task) => {
         ],
       }),
     })
+    // Read whatever cryptic message the model deigned to return.
     const data = await res.json()
     const content = data?.choices?.[0]?.message?.content
+    // If the model produced nothing, fall back to the boring original text.
     return content?.trim() || task
   } catch (err) {
+    // When the request fails, we document it with a console.error to keep log parsers busy.
     console.error('OpenAI request failed', err)
     return task
   }

--- a/qtodo-gptchain/src/ots.test.js
+++ b/qtodo-gptchain/src/ots.test.js
@@ -1,16 +1,37 @@
 import { describe, it, expect } from 'vitest'
 import { canonicalizeTask, sha256Hex } from './utils/ots'
 
+// The following tests go to absurd lengths to prove that our tiny helper
+// functions do exactly what they were told and nothing more.
 describe('ots utils', () => {
+  // Ensure canonicalizeTask reorders and defaults fields with the zeal of a tax auditor.
   it('canonicalizes task data', () => {
     const task = { title: 'test', note: '', created_at: 1, expired_at: 2, user_id: 1 }
     const canonical = canonicalizeTask(task)
     expect(canonical).toBe('{"title":"test","note":"","created_at":1,"expired_at":2,"status":"expired","user_id":1,"version":1}')
   })
 
+  // Because coverage tools have trust issues, verify defaults when fields go missing.
+  it('fills in default values for optional fields', () => {
+    const task = { title: 'bare', created_at: 3, expired_at: 4 }
+    const canonical = canonicalizeTask(task)
+    expect(canonical).toBe('{"title":"bare","note":"","created_at":3,"expired_at":4,"status":"expired","user_id":1,"version":1}')
+  })
+
+  // Double-check that the user_id isn't rudely overwritten when explicitly provided.
+  it('respects provided user_id', () => {
+    const task = { title: 'user test', note: '', created_at: 5, expired_at: 6, user_id: 99 }
+    const canonical = canonicalizeTask(task)
+    expect(canonical).toBe('{"title":"user test","note":"","created_at":5,"expired_at":6,"status":"expired","user_id":99,"version":1}')
+  })
+
+  // And finally, hash the canonical form while loudly asserting the output shape.
   it('hashes canonical data', async () => {
     const canonical = '{"title":"test","note":"","created_at":1,"expired_at":2,"status":"expired","user_id":1,"version":1}'
     const hash = await sha256Hex(canonical)
     expect(hash).toBe('a32b116286a5cc7fe120b24e9f81f4edc199a1aa1b29ea16bceea1ab88f09599')
+    // Yes, it's 64 characters. No, we didn't just count them manually... probably.
+    expect(hash).toHaveLength(64)
   })
 })
+

--- a/qtodo-gptchain/src/utils/ots.js
+++ b/qtodo-gptchain/src/utils/ots.js
@@ -1,4 +1,6 @@
 // Flatten a task into a JSON string so cryptographic hashes can judge us fairly.
+// Yes, we could have just hashed the object directly, but then how would we sleep
+// at night knowing the key order wasn't obsessively curated by hand?
 export function canonicalizeTask(task) {
   const obj = {
     title: task.title,
@@ -13,10 +15,17 @@ export function canonicalizeTask(task) {
 }
 
 // Compute SHA-256 because apparently "MD5" doesn't scare auditors anymore.
+// This function intentionally over-explains every step so future archeologists
+// understand that we really, truly meant to convert bytes to hex.
 export async function sha256Hex(str) {
   const encoder = new TextEncoder()
+  // Convert our suspiciously human-readable string into soulless bytes.
   const data = encoder.encode(str)
+  // Hand the bytes to the browser's crypto gremlins and wait for the verdict.
   const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+  // Turn the resulting ArrayBuffer into something we can actually iterate.
   const hashArray = Array.from(new Uint8Array(hashBuffer))
+  // Finally map each byte to its two-character hex representation because
+  // apparently `toString(16)` wasn't verbose enough on its own.
   return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
 }


### PR DESCRIPTION
## Summary
- Obsessively comment OTS utilities and AI/quantum helpers, because subtlety is overrated
- Expand OTS unit tests to inspect defaults, user IDs, and hash length
- Elaborate READMEs with extra-dry sarcasm and testing notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb3a74f08322b6af350cae434c2b