### PR TITLE
feat: add failure leaderboard

### DIFF
--- a/qtodo-gptchain/src/App.test.jsx
+++ b/qtodo-gptchain/src/App.test.jsx
@@ -34,7 +34,7 @@ describe('App', () => {
   it('adds tasks rendered as haiku', async () => {
     // Provide a bogus API key so generateHaiku thinks it's rich.
     import.meta.env.VITE_OPENAI_API_KEY = 'test'
-    vi.spyOn(global, 'fetch').mockResolvedValue({
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       json: () =>
         Promise.resolve({
           choices: [{ message: { content: 'mystic haiku' } }],
@@ -77,7 +77,7 @@ describe('App', () => {
   })
 
   it('deletes unexpired task and blocks expired', () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue({
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       json: () => Promise.resolve({ data: [0, 1] }),
     })
     const tasks = [

--- a/qtodo-gptchain/src/Failure.jsx
+++ b/qtodo-gptchain/src/Failure.jsx
@@ -1,0 +1,56 @@
+import { getRankTitle } from './utils/failure'
+
+export default function Failure({ stats, resetStats, exportCsv }) {
+  const historyEntries = Object.entries(stats.history)
+    .sort((a, b) => b[0].localeCompare(a[0]))
+    .slice(0, 7)
+
+  const rank = getRankTitle(stats.shame_points)
+
+  return (
+    <div className="p-4 text-left">
+      <div className="mb-4 text-center">
+        <div className="text-5xl">{stats.shame_points}</div>
+        <div className="italic">{rank}</div>
+      </div>
+      <div className="mb-4 space-y-1">
+        <div>Total expired: {stats.total_expired}</div>
+        <div>Total deleted unfinished: {stats.total_deleted_unfinished}</div>
+        <div>Procrastination streak: {stats.procrastination_streak_days} days</div>
+      </div>
+      <table className="w-full mb-4">
+        <thead>
+          <tr className="text-left">
+            <th className="border px-2">Date</th>
+            <th className="border px-2">Expired</th>
+            <th className="border px-2">Deleted</th>
+            <th className="border px-2">Completed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {historyEntries.map(([date, h]) => (
+            <tr key={date}>
+              <td className="border px-2">{date}</td>
+              <td className="border px-2">{h.expired}</td>
+              <td className="border px-2">{h.deleted}</td>
+              <td className="border px-2">{h.completed}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="space-x-2">
+        <button onClick={exportCsv} className="border px-2 py-1">
+          Export CSV
+        </button>
+        <button
+          onClick={() => {
+            if (window.confirm('Reset all failure stats?')) resetStats()
+          }}
+          className="border px-2 py-1"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/qtodo-gptchain/src/failure.test.js
+++ b/qtodo-gptchain/src/failure.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+import {
+  calculatePoints,
+  createDefaultStats,
+  processDateRollover,
+  recordEvent,
+} from './utils/failure'
+
+describe('failure stats', () => {
+  test('points formula', () => {
+    expect(calculatePoints(2, 3, 4)).toBe(2 * 5 + 3 * 2 + 4)
+  })
+
+  test('date rollovers', () => {
+    let stats = createDefaultStats()
+    stats.lastDate = '2024-01-01'
+    stats.history['2024-01-01'] = { expired: 0, deleted: 0, completed: 0 }
+    stats = processDateRollover(stats, '2024-01-02')
+    expect(stats.shame_points).toBe(1)
+    expect(stats.procrastination_streak_days).toBe(1)
+    stats = recordEvent(stats, 'completed', '2024-01-02')
+    stats = processDateRollover(stats, '2024-01-03')
+    expect(stats.procrastination_streak_days).toBe(0)
+  })
+})

--- a/qtodo-gptchain/src/utils/failure.js
+++ b/qtodo-gptchain/src/utils/failure.js
@@ -1,0 +1,100 @@
+export function createDefaultStats() {
+  return {
+    total_expired: 0,
+    total_deleted_unfinished: 0,
+    procrastination_streak_days: 0,
+    shame_points: 0,
+    history: {},
+    lastDate: null,
+  }
+}
+
+function cloneHistory(history) {
+  const copy = {}
+  for (const [k, v] of Object.entries(history)) {
+    copy[k] = { ...v }
+  }
+  return copy
+}
+
+export function getTodayUTC() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export function processDateRollover(stats, today = getTodayUTC()) {
+  const s = { ...stats, history: cloneHistory(stats.history) }
+  const dayMs = 86_400_000
+  if (!s.lastDate) {
+    s.lastDate = today
+    if (!s.history[today]) s.history[today] = { expired: 0, deleted: 0, completed: 0 }
+    return s
+  }
+  let current = new Date(`${s.lastDate}T00:00:00Z`)
+  const target = new Date(`${today}T00:00:00Z`)
+  while (current < target) {
+    const d = current.toISOString().slice(0, 10)
+    const dayStats = s.history[d] || { expired: 0, deleted: 0, completed: 0 }
+    if (dayStats.completed === 0) {
+      s.procrastination_streak_days += 1
+      s.shame_points += 1
+    } else {
+      s.procrastination_streak_days = 0
+    }
+    s.history[d] = dayStats
+    current = new Date(current.getTime() + dayMs)
+  }
+  if (!s.history[today]) s.history[today] = { expired: 0, deleted: 0, completed: 0 }
+  s.lastDate = today
+  return s
+}
+
+export function recordEvent(stats, type, today = getTodayUTC()) {
+  let s = processDateRollover(stats, today)
+  const day = { ...s.history[today] }
+  if (!('expired' in day)) {
+    day.expired = 0
+    day.deleted = 0
+    day.completed = 0
+  }
+  switch (type) {
+    case 'expired':
+      s.total_expired += 1
+      s.shame_points += 5
+      day.expired += 1
+      break
+    case 'deleted':
+      s.total_deleted_unfinished += 1
+      s.shame_points += 2
+      day.deleted += 1
+      break
+    case 'completed':
+      day.completed += 1
+      s.procrastination_streak_days = 0
+      break
+    default:
+      break
+  }
+  s.history[today] = day
+  return s
+}
+
+export function getRankTitle(points) {
+  if (points < 10) return 'Mildly Guilty'
+  if (points < 50) return 'Procrastination Apprentice'
+  if (points < 100) return 'Master of Delay'
+  return 'Overlord of Sloth'
+}
+
+export function historyToCsv(history) {
+  const rows = [['date', 'expired', 'deleted', 'completed']]
+  const dates = Object.keys(history).sort()
+  for (const d of dates) {
+    const h = history[d]
+    rows.push([d, h.expired, h.deleted, h.completed])
+  }
+  return rows.map((r) => r.join(',')).join('\n')
+}
+
+export function calculatePoints(expired, deleted, zeroDays) {
+  return expired * 5 + deleted * 2 + zeroDays
+}


### PR DESCRIPTION
## Summary
- track failure stats in localStorage with shame points and streaks
- add Failure view with daily history, rank title and CSV export
- wire up tasks to increment shame and reset streak on completion

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f365c754832299a7a03a5a6f9d88