### PR TITLE
docs: describe failure stats feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ checkbox and a database table were enough, brace yourself.
   like an embarrassing tweet.
 - **Self-destruct mode** – press the big red button and the entire list immolates
   itself, perfect for those moments when your best plan is scorched earth productivity.
+- **Failure stats and shame points** – track expired and deleted tasks,
+  watch your procrastination streak grow, and climb from "Mildly Guilty"
+  all the way to "Overlord of Sloth".
 - **OpenTimestamps proofs** – expired tasks can be hashed in-browser and timestamped
   without ever leaking their contents. Proofs are created, verified and upgraded via a
   tiny FastAPI server that exists solely to confuse future archaeologists.

--- a/qtodo-gptchain/README.md
+++ b/qtodo-gptchain/README.md
@@ -9,6 +9,8 @@ identity crisis.
 - Tasks are lovingly transmogrified into enigmatic haiku by the OpenAI API.
 - Daily quantum random shuffling keeps you guessing which chore comes next.
 - A blinking ASCII banner to prove we care more about aesthetics than usefulness.
+- Failure stats with shame points and ranks — watch expired and deleted tasks
+  pile up as you rise from "Mildly Guilty" to "Overlord of Sloth".
 - LocalStorage persistence so your confusion survives every refresh.
 - Assign expiry dates to tasks; once a task's time is up, it's immortal and
   can no longer be deleted.


### PR DESCRIPTION
## Summary
- replace "leaderboard" with failure stats bullet in top-level README
- mention shame points and rank titles in qtodo-gptchain README

## Testing
- `cd qtodo-gptchain && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f592c1e08322ac052c7e45d3eb67