### PR TITLE
Add logging and full-chain contract mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,15 @@ EVM_PRIVATE_KEY=0x...
 EVM_CONTRACT_ADDRESS=0x...
 EVM_CHAIN=base-sepolia
 EVM_EXPLORER=https://sepolia.basescan.org
+EVM_MODE=lite
 ```
 
-The contract source lives in `evm/Anchor.sol` and does little more than shout an
-event into the void.
+Set `EVM_MODE=full` if you actually want the chain to remember your hashes. In
+`lite` mode (the default) the contract simply emits an event. When switched to
+`full` it persists the hash and a reference string on-chain for all eternity.
+
+The contract source lives in `evm/Anchor.sol` and can operate in either mode,
+letting you choose between fiscal responsibility and glorious waste.
 
 ## Development
 

--- a/evm/Anchor.sol
+++ b/evm/Anchor.sol
@@ -1,11 +1,39 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// A contract that favours events over storage, in true minimalist fashion.
+// A contract that can either lazily emit events or, for those with more
+// ether than restraint, persist hashes directly on-chain.
 contract Anchor {
-    event Recorded(bytes32 hash, string ref, address who);
+    struct Task {
+        bytes32 hash;
+        string ref;
+        address who;
+        uint256 timestamp;
+    }
 
+    event Recorded(bytes32 hash, string ref, address who);
+    event Stored(bytes32 hash, string ref, address who);
+
+    mapping(bytes32 => Task) public tasks;
+
+    // Lite mode – emit an event and move on.
     function record(bytes32 hash, string calldata ref) external {
         emit Recorded(hash, ref, msg.sender);
+    }
+
+    // Full-fat mode – write the task to storage so it can haunt us forever.
+    function store(bytes32 hash, string calldata ref) external {
+        tasks[hash] = Task(hash, ref, msg.sender, block.timestamp);
+        emit Stored(hash, ref, msg.sender);
+    }
+
+    // Retrieve a stored task. Returns zero values if the hash is unknown.
+    function getTask(bytes32 hash)
+        external
+        view
+        returns (bytes32, string memory, address, uint256)
+    {
+        Task storage t = tasks[hash];
+        return (t.hash, t.ref, t.who, t.timestamp);
     }
 }

--- a/ots-server/main.py
+++ b/ots-server/main.py
@@ -2,8 +2,12 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import base64
 import os
+import logging
 from web3 import Web3
 from opentimestamps.client import Client
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 client = Client()
@@ -15,6 +19,7 @@ PRIV_KEY = os.getenv('EVM_PRIVATE_KEY')
 CONTRACT_ADDR = os.getenv('EVM_CONTRACT_ADDRESS')
 CHAIN_NAME = os.getenv('EVM_CHAIN', 'unknown')
 EXPLORER = os.getenv('EVM_EXPLORER', '')
+EVM_MODE = os.getenv('EVM_MODE', 'lite')
 
 web3 = Web3(Web3.HTTPProvider(RPC_URL)) if RPC_URL else None
 account = web3.eth.account.from_key(PRIV_KEY) if web3 and PRIV_KEY else None
@@ -22,25 +27,135 @@ ABI = [
     {
         'anonymous': False,
         'inputs': [
-            {'indexed': False, 'internalType': 'bytes32', 'name': 'hash', 'type': 'bytes32'},
-            {'indexed': False, 'internalType': 'string', 'name': 'ref', 'type': 'string'},
-            {'indexed': False, 'internalType': 'address', 'name': 'who', 'type': 'address'},
+            {
+                'indexed': False,
+                'internalType': 'bytes32',
+                'name': 'hash',
+                'type': 'bytes32',
+            },
+            {
+                'indexed': False,
+                'internalType': 'string',
+                'name': 'ref',
+                'type': 'string',
+            },
+            {
+                'indexed': False,
+                'internalType': 'address',
+                'name': 'who',
+                'type': 'address',
+            },
         ],
         'name': 'Recorded',
         'type': 'event',
     },
     {
+        'anonymous': False,
         'inputs': [
-            {'internalType': 'bytes32', 'name': 'hash', 'type': 'bytes32'},
-            {'internalType': 'string', 'name': 'ref', 'type': 'string'},
+            {
+                'indexed': False,
+                'internalType': 'bytes32',
+                'name': 'hash',
+                'type': 'bytes32',
+            },
+            {
+                'indexed': False,
+                'internalType': 'string',
+                'name': 'ref',
+                'type': 'string',
+            },
+            {
+                'indexed': False,
+                'internalType': 'address',
+                'name': 'who',
+                'type': 'address',
+            },
+        ],
+        'name': 'Stored',
+        'type': 'event',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'bytes32',
+                'name': 'hash',
+                'type': 'bytes32',
+            },
+            {
+                'internalType': 'string',
+                'name': 'ref',
+                'type': 'string',
+            },
         ],
         'name': 'record',
         'outputs': [],
         'stateMutability': 'nonpayable',
         'type': 'function',
     },
+    {
+        'inputs': [
+            {
+                'internalType': 'bytes32',
+                'name': 'hash',
+                'type': 'bytes32',
+            },
+            {
+                'internalType': 'string',
+                'name': 'ref',
+                'type': 'string',
+            },
+        ],
+        'name': 'store',
+        'outputs': [],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'bytes32',
+                'name': 'hash',
+                'type': 'bytes32',
+            }
+        ],
+        'name': 'getTask',
+        'outputs': [
+            {
+                'internalType': 'bytes32',
+                'name': 'hash',
+                'type': 'bytes32',
+            },
+            {
+                'internalType': 'string',
+                'name': 'ref',
+                'type': 'string',
+            },
+            {
+                'internalType': 'address',
+                'name': 'who',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'timestamp',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
 ]
 contract = web3.eth.contract(address=CONTRACT_ADDR, abi=ABI) if web3 and CONTRACT_ADDR else None
+
+if contract:
+    logger.info(
+        'EVM configured for chain %s, contract %s, mode %s',
+        CHAIN_NAME,
+        CONTRACT_ADDR,
+        EVM_MODE,
+    )
+else:
+    logger.warning('EVM not configured; blockchain features disabled')
 
 class HashReq(BaseModel):
     hash: str
@@ -63,57 +178,91 @@ class AnchorVerifyReq(BaseModel):
 
 @app.post('/ots/create')
 def create(req: HashReq):
-    proof = client.create(bytes.fromhex(req.hash))
-    return {'proof': base64.b64encode(proof).decode()}
+    logger.info('OTS create for %s', req.hash)
+    try:
+        proof = client.create(bytes.fromhex(req.hash))
+        return {'proof': base64.b64encode(proof).decode()}
+    except Exception:
+        logger.exception('OTS create failed')
+        raise HTTPException(status_code=500, detail='OTS create failed')
 
 @app.post('/ots/verify')
 def verify(req: VerifyReq):
-    proof = base64.b64decode(req.proof)
-    ok = client.verify(bytes.fromhex(req.hash), proof)
-    return {'verified': ok}
+    logger.info('OTS verify for %s', req.hash)
+    try:
+        proof = base64.b64decode(req.proof)
+        ok = client.verify(bytes.fromhex(req.hash), proof)
+        return {'verified': ok}
+    except Exception:
+        logger.exception('OTS verify failed')
+        raise HTTPException(status_code=500, detail='OTS verify failed')
 
 @app.post('/ots/upgrade')
 def upgrade(req: UpgradeReq):
-    proof = base64.b64decode(req.proof)
-    upgraded = client.upgrade(proof)
-    return {'proof': base64.b64encode(upgraded).decode()}
+    logger.info('OTS upgrade request')
+    try:
+        proof = base64.b64decode(req.proof)
+        upgraded = client.upgrade(proof)
+        return {'proof': base64.b64encode(upgraded).decode()}
+    except Exception:
+        logger.exception('OTS upgrade failed')
+        raise HTTPException(status_code=500, detail='OTS upgrade failed')
 
 
 @app.post('/evm/anchor')
 def anchor(req: AnchorReq):
+    logger.info('EVM anchor for %s', req.hash)
     if not contract or not account:
+        logger.error('EVM not configured')
         raise HTTPException(status_code=500, detail='EVM not configured')
-    # Send the hash to chain in the most miserly manner possible.
-    nonce = web3.eth.get_transaction_count(account.address)
-    txn = contract.functions.record(Web3.to_bytes(hexstr=req.hash), req.ref).build_transaction(
-        {
-            'from': account.address,
-            'nonce': nonce,
-            'gas': 100000,
-            'gasPrice': web3.eth.gas_price,
+    try:
+        nonce = web3.eth.get_transaction_count(account.address)
+        func = (
+            contract.functions.store
+            if EVM_MODE != 'lite'
+            else contract.functions.record
+        )
+        txn = func(Web3.to_bytes(hexstr=req.hash), req.ref).build_transaction(
+            {
+                'from': account.address,
+                'nonce': nonce,
+                'gas': 100000,
+                'gasPrice': web3.eth.gas_price,
+            }
+        )
+        signed = account.sign_transaction(txn)
+        tx_hash = web3.eth.send_raw_transaction(signed.rawTransaction)
+        web3.eth.wait_for_transaction_receipt(tx_hash)
+        explorer = f"{EXPLORER}/tx/{tx_hash.hex()}" if EXPLORER else ''
+        logger.info('Anchored %s in tx %s', req.hash, tx_hash.hex())
+        return {
+            'tx': tx_hash.hex(),
+            'contract': CONTRACT_ADDR,
+            'chain': CHAIN_NAME,
+            'explorer': explorer,
         }
-    )
-    signed = account.sign_transaction(txn)
-    tx_hash = web3.eth.send_raw_transaction(signed.rawTransaction)
-    web3.eth.wait_for_transaction_receipt(tx_hash)
-    explorer = f"{EXPLORER}/tx/{tx_hash.hex()}" if EXPLORER else ''
-    return {
-        'tx': tx_hash.hex(),
-        'contract': CONTRACT_ADDR,
-        'chain': CHAIN_NAME,
-        'explorer': explorer,
-    }
+    except Exception:
+        logger.exception('EVM anchor failed')
+        raise HTTPException(status_code=500, detail='EVM anchor failed')
 
 
 @app.post('/evm/verify')
 def verify_anchor(req: AnchorVerifyReq):
+    logger.info('EVM verify for %s', req.hash)
     if not contract:
+        logger.error('EVM not configured')
         raise HTTPException(status_code=500, detail='EVM not configured')
-    # Look back through the chain to find the matching event.
-    logs = contract.events.Recorded.create_filter(
-        fromBlock=0, argument_filters={'hash': Web3.to_bytes(hexstr=req.hash)}
-    ).get_all_entries()
-    if logs:
-        tx_hash = logs[-1]['transactionHash'].hex()
-        return {'found': True, 'tx': tx_hash}
-    return {'found': False}
+    try:
+        event = (
+            contract.events.Stored if EVM_MODE != 'lite' else contract.events.Recorded
+        )
+        logs = event.create_filter(
+            fromBlock=0, argument_filters={'hash': Web3.to_bytes(hexstr=req.hash)}
+        ).get_all_entries()
+        if logs:
+            tx_hash = logs[-1]['transactionHash'].hex()
+            return {'found': True, 'tx': tx_hash}
+        return {'found': False}
+    except Exception:
+        logger.exception('EVM verify failed')
+        raise HTTPException(status_code=500, detail='EVM verify failed')

--- a/qtodo-gptchain/src/App.jsx
+++ b/qtodo-gptchain/src/App.jsx
@@ -135,105 +135,126 @@ function App() {
   const createProof = async (index) => {
     const task = tasks[index]
     if (!task.otsMeta?.hash) return
-    const res = await fetch('http://localhost:8000/ots/create', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ hash: task.otsMeta.hash }),
-    })
-    const data = await res.json()
-    setTasks((prev) => {
-      const copy = [...prev]
-      copy[index] = {
-        ...copy[index],
-        otsMeta: { ...copy[index].otsMeta, proof: data.proof, status: 'created' },
-      }
-      return copy
-    })
+    try {
+      const res = await fetch('http://localhost:8000/ots/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hash: task.otsMeta.hash }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setTasks((prev) => {
+        const copy = [...prev]
+        copy[index] = {
+          ...copy[index],
+          otsMeta: { ...copy[index].otsMeta, proof: data.proof, status: 'created' },
+        }
+        return copy
+      })
+    } catch (err) {
+      console.error('createProof failed', err)
+    }
   }
 
   const verifyProof = async (index) => {
     const task = tasks[index]
     if (!task.otsMeta?.proof) return
-    const res = await fetch('http://localhost:8000/ots/verify', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ hash: task.otsMeta.hash, proof: task.otsMeta.proof }),
-    })
-    const data = await res.json()
-    setTasks((prev) => {
-      const copy = [...prev]
-      copy[index] = {
-        ...copy[index],
-        otsMeta: {
-          ...copy[index].otsMeta,
-          status: data.verified ? 'verified' : 'invalid',
-        },
-      }
-      return copy
-    })
+    try {
+      const res = await fetch('http://localhost:8000/ots/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hash: task.otsMeta.hash, proof: task.otsMeta.proof }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setTasks((prev) => {
+        const copy = [...prev]
+        copy[index] = {
+          ...copy[index],
+          otsMeta: {
+            ...copy[index].otsMeta,
+            status: data.verified ? 'verified' : 'invalid',
+          },
+        }
+        return copy
+      })
+    } catch (err) {
+      console.error('verifyProof failed', err)
+    }
   }
 
   const upgradeProof = async (index) => {
     const task = tasks[index]
     if (!task.otsMeta?.proof) return
-    const res = await fetch('http://localhost:8000/ots/upgrade', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ proof: task.otsMeta.proof }),
-    })
-    const data = await res.json()
-    setTasks((prev) => {
-      const copy = [...prev]
-      copy[index] = {
-        ...copy[index],
-        otsMeta: { ...copy[index].otsMeta, proof: data.proof, status: 'upgraded' },
-      }
-      return copy
-    })
+    try {
+      const res = await fetch('http://localhost:8000/ots/upgrade', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ proof: task.otsMeta.proof }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setTasks((prev) => {
+        const copy = [...prev]
+        copy[index] = {
+          ...copy[index],
+          otsMeta: { ...copy[index].otsMeta, proof: data.proof, status: 'upgraded' },
+        }
+        return copy
+      })
+    } catch (err) {
+      console.error('upgradeProof failed', err)
+    }
   }
 
   // Politely ask the chain to remember our hash.
   const anchorOnChain = async (index) => {
     const task = tasks[index]
     if (!task.otsMeta?.hash || !task.otsMeta?.ref) return
-    const res = await fetch('http://localhost:8000/evm/anchor', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ hash: task.otsMeta.hash, ref: task.otsMeta.ref }),
-    })
-    const data = await res.json()
-    setTasks((prev) => {
-      const copy = [...prev]
-      copy[index] = {
-        ...copy[index],
-        otsMeta: {
-          ...copy[index].otsMeta,
-          chain: data.chain,
-          contract: data.contract,
-          tx: data.tx,
-          explorer: data.explorer,
-          lastVerification: 'pending',
-        },
-      }
-      return copy
-    })
-    const vRes = await fetch('http://localhost:8000/evm/verify', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ hash: task.otsMeta.hash }),
-    })
-    const vData = await vRes.json()
-    setTasks((prev) => {
-      const copy = [...prev]
-      copy[index] = {
-        ...copy[index],
-        otsMeta: {
-          ...copy[index].otsMeta,
-          lastVerification: vData.found ? 'recorded' : 'missing',
-        },
-      }
-      return copy
-    })
+    try {
+      const res = await fetch('http://localhost:8000/evm/anchor', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hash: task.otsMeta.hash, ref: task.otsMeta.ref }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setTasks((prev) => {
+        const copy = [...prev]
+        copy[index] = {
+          ...copy[index],
+          otsMeta: {
+            ...copy[index].otsMeta,
+            chain: data.chain,
+            contract: data.contract,
+            tx: data.tx,
+            explorer: data.explorer,
+            lastVerification: 'pending',
+          },
+        }
+        return copy
+      })
+      const vRes = await fetch('http://localhost:8000/evm/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hash: task.otsMeta.hash }),
+      })
+      if (!vRes.ok) throw new Error(`HTTP ${vRes.status}`)
+      const vData = await vRes.json()
+      setTasks((prev) => {
+        const copy = [...prev]
+        copy[index] = {
+          ...copy[index],
+          otsMeta: {
+            ...copy[index].otsMeta,
+            lastVerification: vData.found ? 'recorded' : 'missing',
+          },
+        }
+        return copy
+      })
+    } catch (err) {
+      console.error('anchorOnChain failed', err)
+    }
   }
 
   const selfDestruct = async () => {


### PR DESCRIPTION
## Summary
- expand Anchor.sol to optionally store task hashes on-chain
- add extensive logging and EVM mode toggle to ots-server
- harden frontend network calls with error handling
- document new EVM_MODE in README

## Testing
- `npm test`
- `python -m py_compile ots-server/main.py`
- `solcjs --bin evm/Anchor.sol -o /tmp/solc_out`


------
https://chatgpt.com/codex/tasks/task_e_68b9fa58dd088322a4c8e2941c8b8953