### PR TITLE
docs: expand readmes and sprinkle jokes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ Set `EVM_MODE=full` if you actually want the chain to remember your hashes. In
 The contract source lives in `evm/Anchor.sol` and can operate in either mode,
 letting you choose between fiscal responsibility and glorious waste.
 
+## Tour of the Repository
+
+- **qtodo-gptchain/** – the front end where tasks become poetry and checkboxes learn
+  shame.
+- **ots-server/** – a FastAPI helper that lovingly wraps OpenTimestamps and pretends
+  to be a blockchain whisperer.
+- **evm/** – contains a Solidity contract that exists solely so your chores can
+  hit the chain and feel important for a few seconds.
+
+If you stumbled all the way down here, the secret passphrase is
+`"nothing says productivity like twelve microservices"`.
+
+<!-- Easter egg: you have unlocked the hidden level. Sadly, it only contains more
+     documentation. -->
+
 ## Development
 
 ```bash

--- a/evm/Anchor.sol
+++ b/evm/Anchor.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 
 // A contract that can either lazily emit events or, for those with more
 // ether than restraint, persist hashes directly on-chain.
+// If you're reading this comment, welcome to the secret society of people who
+// scroll past documentation.
 contract Anchor {
     struct Task {
         bytes32 hash;
@@ -18,13 +20,13 @@ contract Anchor {
 
     // Lite mode – emit an event and move on.
     function record(bytes32 hash, string calldata ref) external {
-        emit Recorded(hash, ref, msg.sender);
+        emit Recorded(hash, ref, msg.sender); // Event-based therapy for your tasks.
     }
 
     // Full-fat mode – write the task to storage so it can haunt us forever.
     function store(bytes32 hash, string calldata ref) external {
-        tasks[hash] = Task(hash, ref, msg.sender, block.timestamp);
-        emit Stored(hash, ref, msg.sender);
+        tasks[hash] = Task(hash, ref, msg.sender, block.timestamp); // Now it's permanent.
+        emit Stored(hash, ref, msg.sender); // May the gas fee be ever in your favor.
     }
 
     // Retrieve a stored task. Returns zero values if the hash is unknown.

--- a/evm/README.md
+++ b/evm/README.md
@@ -1,0 +1,19 @@
+# EVM Anchoring Contract
+
+This folder holds `Anchor.sol`, a contract that can either shout hashes into the
+void or etch them onto chain forever.
+
+## Modes
+
+- **Lite** – call `record` and an event is emitted, nothing is stored, and the
+  gas meter barely flinches.
+- **Full** – call `store` and the hash, a reference and your address are kept
+  on-chain so future archaeologists can marvel at your chores.
+
+## Easter Egg
+
+If you name your task `"solidity makes me type"`, nothing special happens, but
+you'll know we tried.
+
+<!-- Secret handshake: `pragma solidity ^0.8.0;` -->
+

--- a/ots-server/README.md
+++ b/ots-server/README.md
@@ -1,0 +1,22 @@
+# OpenTimestamps Helper
+
+`ots-server` is a tiny FastAPI service that turns SHA-256 hashes into cryptic
+proofs and occasionally hurls them at an EVM chain.
+
+## Quickstart
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Set the `EVM_*` environment variables if you want on-chain antics; otherwise it
+quietly pretends blockchains never happened.
+
+## Easter Egg
+
+If the server logs "beep boop" on startup, you've accidentally triggered
+debug mode. Spoiler: there is no debug mode.
+
+<!-- The cake is a lie, but the timestamps are real. -->
+

--- a/ots-server/main.py
+++ b/ots-server/main.py
@@ -12,6 +12,9 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 client = Client()
 
+# This server exists mainly so hashes can feel important before fading into
+# obscurity. Think of it as a timestamping spa.
+
 # EVM client setup. All variables are optional so the server still works
 # without a chain connection.
 RPC_URL = os.getenv('EVM_RPC_URL')

--- a/qtodo-gptchain/README.md
+++ b/qtodo-gptchain/README.md
@@ -47,3 +47,14 @@ uvicorn main:app --reload
 
 Set `VITE_OPENAI_API_KEY` in your environment if you actually want the AI to
 rewrite your tasks. Otherwise, enjoy plain text like it's 1999.
+
+## Hidden Features
+
+- Press `Ctrl+Alt+Shift+Y` to enable "yodel mode".*
+- Triple-click the ASCII art for a motivational quote so cryptic it may be a
+  bug.
+
+\*Not actually implemented, but believing is half the battle.
+
+<!-- If you're digging for secrets, try adding a task named "42". Nothing happens,
+     but you'll feel clever. -->

--- a/qtodo-gptchain/src/main.jsx
+++ b/qtodo-gptchain/src/main.jsx
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 
+// Entry point to the chaos. Rendering begins here, abandon simplicity all ye who enter.
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- elaborate root README with a tour of repository and a secret passphrase
- add individual READMEs for evm and ots-server, complete with tiny easter eggs
- scatter playful comments across code and entry point for extra levity

## Testing
- `npm test`
- `pytest`
- `solc --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba00bff40c83228378c83403b870aa