### PR TITLE
docs: clarify module capabilities

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -10,6 +10,11 @@ void or etch them onto chain forever.
 - **Full** – call `store` and the hash, a reference and your address are kept
   on-chain so future archaeologists can marvel at your chores.
 
+## Retrieval
+
+Should nostalgia strike, call `getTask(bytes32)` to fetch a stored hash, its
+reference, who anchored it and when. Unknown hashes return empty values.
+
 ## Easter Egg
 
 If you name your task `"solidity makes me type"`, nothing special happens, but

--- a/ots-server/README.md
+++ b/ots-server/README.md
@@ -13,6 +13,14 @@ uvicorn main:app --reload
 Set the `EVM_*` environment variables if you want on-chain antics; otherwise it
 quietly pretends blockchains never happened.
 
+## Endpoints
+
+- `POST /ots/create` – return a base64-encoded OpenTimestamps proof for a hex hash.
+- `POST /ots/verify` – check a hash against a proof.
+- `POST /ots/upgrade` – ask the network to upgrade a proof.
+- `POST /evm/anchor` – record or store the hash on-chain when EVM settings are configured.
+- `POST /evm/verify` – confirm whether a hash was anchored.
+
 ## Easter Egg
 
 If the server logs "beep boop" on startup, you've accidentally triggered

--- a/qtodo-gptchain/README.md
+++ b/qtodo-gptchain/README.md
@@ -11,9 +11,12 @@ identity crisis.
 - A blinking ASCII banner to prove we care more about aesthetics than usefulness.
 - Failure stats with shame points and ranks — watch expired and deleted tasks
   pile up as you rise from "Mildly Guilty" to "Overlord of Sloth".
+- Export those stats as CSV for anyone who enjoys spreadsheet-driven regret.
 - LocalStorage persistence so your confusion survives every refresh.
 - Assign expiry dates to tasks; once a task's time is up, it's immortal and
   can no longer be deleted.
+- A self-destruct button initiates an earnest countdown before wiping all
+  non-expired tasks.
 - Expired tasks can be timestamped with OpenTimestamps. The app hashes the task locally
   and sends only the hash to a small FastAPI helper for proof creation, verification and
   upgrades.


### PR DESCRIPTION
## Summary
- describe CSV export and self-destruct features in qtodo frontend docs
- outline OTS and EVM endpoints in helper server
- mention retrieval helper in EVM contract readme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba030681f8832297d5672142448c83