### PR TITLE
feat: add retro SQLite todo service

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ checkbox and a database table were enough, brace yourself.
   string on-chain and bask in the permanence.
 - **Blinking ASCII art** – because a todo app without terminal nostalgia is hardly
   worth opening. Bring your own CRT monitor for maximum effect.
+- **SQLite-backed madness** – a tiny FastAPI service keeps user accounts and todos
+  in a real database, which obviously prints ASCII art when it boots.
 - **LocalStorage persistence** – your list survives refreshes and browser restarts so
   you can keep not doing things indefinitely. Congratulations, you've invented memory.
 - **Modern stack** – built with React, Vite and TailwindCSS for absolutely no reason
@@ -66,13 +68,21 @@ npm test
 If those tests pass, feel free to frame the output and mail it to your future self
 as proof you once had things under control.
 
-### OpenTimestamps Server
+### OpenTimestamps & Retro DB Server
 
 ```bash
 cd ots-server
 pip install -r requirements.txt
 uvicorn main:app --reload
 ```
+
+This same FastAPI app now moonlights as a tiny SQLite-backed database. It
+prints out chunky ASCII art on startup and exposes a few endpoints so brave
+users can register accounts and stash todos:
+
+- `POST /users/register` – create a user with `username` and `password`
+- `POST /todos/add` – add a todo for a given `user_id`
+- `GET /todos/{user_id}` – list all todos for that user
 
 To indulge the EVM anchoring, set the following environment variables so the
 server knows how to reach your chosen testnet:

--- a/ots-server/README.md
+++ b/ots-server/README.md
@@ -1,7 +1,8 @@
 # OpenTimestamps Helper
 
 `ots-server` is a tiny FastAPI service that turns SHA-256 hashes into cryptic
-proofs and occasionally hurls them at an EVM chain.
+proofs, moonlights as a retro SQLite-backed todo API and occasionally hurls
+data at an EVM chain.
 
 ## Quickstart
 
@@ -13,6 +14,8 @@ uvicorn main:app --reload
 Set the `EVM_*` environment variables if you want on-chain antics; otherwise it
 quietly pretends blockchains never happened.
 
+On boot the server prints a chunky ASCII banner, because subtlety is overrated.
+
 ## Endpoints
 
 - `POST /ots/create` – return a base64-encoded OpenTimestamps proof for a hex hash.
@@ -20,6 +23,9 @@ quietly pretends blockchains never happened.
 - `POST /ots/upgrade` – ask the network to upgrade a proof.
 - `POST /evm/anchor` – record or store the hash on-chain when EVM settings are configured.
 - `POST /evm/verify` – confirm whether a hash was anchored.
+- `POST /users/register` – create a user account.
+- `POST /todos/add` – add a todo for a user.
+- `GET /todos/{user_id}` – list a user's todos.
 
 ## Easter Egg
 


### PR DESCRIPTION
## Summary
- add SQLite-backed user/todo endpoints with an ASCII art splash
- document new retro database service

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba07750e90832280a30bbb3de21d3c