### PR TITLE
Add failure stats CSV docs and bolster test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ checkbox and a database table were enough, brace yourself.
   itself, perfect for those moments when your best plan is scorched earth productivity.
 - **Failure stats and shame points** – track expired and deleted tasks,
   watch your procrastination streak grow, and climb from "Mildly Guilty"
-  all the way to "Overlord of Sloth".
+  all the way to "Overlord of Sloth". Export your humiliation as CSV for
+  spreadsheet-fueled reflection.
 - **OpenTimestamps proofs** – expired tasks can be hashed in-browser and timestamped
   without ever leaking their contents. Proofs are created, verified and upgraded via a
   tiny FastAPI server that exists solely to confuse future archaeologists.

--- a/qtodo-gptchain/src/failure.test.js
+++ b/qtodo-gptchain/src/failure.test.js
@@ -4,6 +4,8 @@ import {
   createDefaultStats,
   processDateRollover,
   recordEvent,
+  getRankTitle,
+  historyToCsv,
 } from './utils/failure'
 
 describe('failure stats', () => {
@@ -21,5 +23,35 @@ describe('failure stats', () => {
     stats = recordEvent(stats, 'completed', '2024-01-02')
     stats = processDateRollover(stats, '2024-01-03')
     expect(stats.procrastination_streak_days).toBe(0)
+  })
+
+  test('record event tallies stats', () => {
+    let stats = createDefaultStats()
+    stats = recordEvent(stats, 'expired', '2024-01-01')
+    stats = recordEvent(stats, 'deleted', '2024-01-01')
+    stats = recordEvent(stats, 'completed', '2024-01-01')
+    expect(stats.total_expired).toBe(1)
+    expect(stats.total_deleted_unfinished).toBe(1)
+    expect(stats.history['2024-01-01']).toEqual({
+      expired: 1,
+      deleted: 1,
+      completed: 1,
+    })
+    expect(stats.shame_points).toBe(7)
+  })
+
+  test('rank titles and csv export', () => {
+    expect(getRankTitle(0)).toBe('Mildly Guilty')
+    expect(getRankTitle(10)).toBe('Procrastination Apprentice')
+    expect(getRankTitle(50)).toBe('Master of Delay')
+    expect(getRankTitle(100)).toBe('Overlord of Sloth')
+    const history = {
+      '2024-01-02': { expired: 1, deleted: 0, completed: 3 },
+      '2024-01-01': { expired: 0, deleted: 1, completed: 2 },
+    }
+    const csv = historyToCsv(history)
+    expect(csv).toBe(
+      'date,expired,deleted,completed\n2024-01-01,0,1,2\n2024-01-02,1,0,3',
+    )
   })
 })


### PR DESCRIPTION
## Summary
- Document failure stats CSV export in the main README
- Expand failure statistics tests to cover event tallying, rank titles and CSV output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba08ef60d0832297bc51ab320e0307