### PR TITLE
test: mock quantum fetch and polyfill crypto

### DIFF
--- a/qtodo-gptchain/src/App.test.jsx
+++ b/qtodo-gptchain/src/App.test.jsx
@@ -115,6 +115,9 @@ describe('App', () => {
   })
 
   it('self destruct spares expired tasks', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: () => Promise.resolve({ data: [0, 1] }),
+    })
     const tasks = [
       {
         title: 'old',

--- a/qtodo-gptchain/src/setupTests.js
+++ b/qtodo-gptchain/src/setupTests.js
@@ -2,3 +2,9 @@ import { expect } from 'vitest'
 import * as matchers from '@testing-library/jest-dom/matchers'
 
 expect.extend(matchers)
+
+// Vitest runs in Node, so provide the Web Crypto API if it's missing
+import { webcrypto } from 'node:crypto'
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, 'crypto', { value: webcrypto })
+}


### PR DESCRIPTION
## Summary
- mock quantum random API in vitest to avoid network failures
- polyfill Web Crypto API for Node test environment

## Testing
- `npm test`
- `pytest`
- `npx -y solc@0.8.30 Anchor.sol --bin --abi -o build`


------
https://chatgpt.com/codex/tasks/task_e_68c014d040408322bcc32fa79d372089