### PR TITLE
fix: make the thing actually run for the first time in recorded history

### DIFF
--- a/ots-server/main.py
+++ b/ots-server/main.py
@@ -1,46 +1,77 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 import base64
+import hashlib
+import io
 import os
 import logging
 import sqlite3
+
+# The opentimestamps library exists because apparently just checking your watch
+# wasn't authoritative enough. We need Bitcoin—a globally-distributed
+# consensus mechanism burning the energy of a small country—to tell us
+# what time it is. Architecture review passed unanimously.
+from opentimestamps.core.timestamp import DetachedTimestampFile, Timestamp
+from opentimestamps.core.op import OpSHA256
+from opentimestamps.core.notary import PendingAttestation, BitcoinBlockHeaderAttestation
+from opentimestamps.core.serialize import StreamSerializationContext, StreamDeserializationContext
+from opentimestamps.calendar import RemoteCalendar, DEFAULT_AGGREGATORS
+
 from web3 import Web3
-from opentimestamps.client import Client
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-app = FastAPI()
-client = Client()
+app = FastAPI(
+    title="QTodo Retro Server",
+    description="A microservice that exists solely to make a todo list feel important.",
+    version="0.0.0-eternal-beta",
+)
+
+# CORS: because browsers are paranoid and the internet is not.
+# allow_origins=['*'] is the YOLO of security configurations, but we're already
+# anchoring grocery lists on a blockchain, so let's not pretend we're cautious.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 ASCII_ART = r"""
-   ____  __________  ____   ____
-  / __ \|___  / __ \|  _ \ / __ \
- | |  | | / / |  | | |_) | |  | |
- | |  | |/ /| |  | |  _ <| |  | |
- | |__| / /__| |__| | |_) | |__| |
-  \____/_____|\____/|____/ \____/
+   ____  _______ ____  __________
+  / __ \/_  __/ |/ _ \/ _  / __ \
+ | |  | | / /  | | | | | | | |  | |
+ | |  | |/ /| | |_| | |_| | |__| |
+ | |__| |/ /__| |\___/ \____/\____/
+  \____//_____/_|
 
  QTodo Retro Server - 1990s Edition
+ Timestamping your procrastination since the genesis block.
 """
 
 print(ASCII_ART)
 
 db = sqlite3.connect('todo.db', check_same_thread=False)
 db.execute(
-    'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT)'
+    'CREATE TABLE IF NOT EXISTS users '
+    '(id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT)'
 )
 db.execute(
-    'CREATE TABLE IF NOT EXISTS todos (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, text TEXT, done INTEGER DEFAULT 0, created TIMESTAMP DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(user_id) REFERENCES users(id))'
+    'CREATE TABLE IF NOT EXISTS todos '
+    '(id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, text TEXT, '
+    'done INTEGER DEFAULT 0, created TIMESTAMP DEFAULT CURRENT_TIMESTAMP, '
+    'FOREIGN KEY(user_id) REFERENCES users(id))'
 )
 db.commit()
 
 # This server exists mainly so hashes can feel important before fading into
-# obscurity. Think of it as a timestamping spa.
+# obscurity. Think of it as a timestamping spa for anxious cryptographic digests.
 
-# EVM client setup. All variables are optional so the server still works
-# without a chain connection.
+# EVM client setup. All variables are optional so the server limps along
+# without a chain connection, like a blockchain enthusiast at a cash-only café.
 RPC_URL = os.getenv('EVM_RPC_URL')
 PRIV_KEY = os.getenv('EVM_PRIVATE_KEY')
 CONTRACT_ADDR = os.getenv('EVM_CONTRACT_ADDRESS')
@@ -54,24 +85,9 @@ ABI = [
     {
         'anonymous': False,
         'inputs': [
-            {
-                'indexed': False,
-                'internalType': 'bytes32',
-                'name': 'hash',
-                'type': 'bytes32',
-            },
-            {
-                'indexed': False,
-                'internalType': 'string',
-                'name': 'ref',
-                'type': 'string',
-            },
-            {
-                'indexed': False,
-                'internalType': 'address',
-                'name': 'who',
-                'type': 'address',
-            },
+            {'indexed': False, 'internalType': 'bytes32', 'name': 'hash', 'type': 'bytes32'},
+            {'indexed': False, 'internalType': 'string', 'name': 'ref', 'type': 'string'},
+            {'indexed': False, 'internalType': 'address', 'name': 'who', 'type': 'address'},
         ],
         'name': 'Recorded',
         'type': 'event',
@@ -79,40 +95,17 @@ ABI = [
     {
         'anonymous': False,
         'inputs': [
-            {
-                'indexed': False,
-                'internalType': 'bytes32',
-                'name': 'hash',
-                'type': 'bytes32',
-            },
-            {
-                'indexed': False,
-                'internalType': 'string',
-                'name': 'ref',
-                'type': 'string',
-            },
-            {
-                'indexed': False,
-                'internalType': 'address',
-                'name': 'who',
-                'type': 'address',
-            },
+            {'indexed': False, 'internalType': 'bytes32', 'name': 'hash', 'type': 'bytes32'},
+            {'indexed': False, 'internalType': 'string', 'name': 'ref', 'type': 'string'},
+            {'indexed': False, 'internalType': 'address', 'name': 'who', 'type': 'address'},
         ],
         'name': 'Stored',
         'type': 'event',
     },
     {
         'inputs': [
-            {
-                'internalType': 'bytes32',
-                'name': 'hash',
-                'type': 'bytes32',
-            },
-            {
-                'internalType': 'string',
-                'name': 'ref',
-                'type': 'string',
-            },
+            {'internalType': 'bytes32', 'name': 'hash', 'type': 'bytes32'},
+            {'internalType': 'string', 'name': 'ref', 'type': 'string'},
         ],
         'name': 'record',
         'outputs': [],
@@ -121,16 +114,8 @@ ABI = [
     },
     {
         'inputs': [
-            {
-                'internalType': 'bytes32',
-                'name': 'hash',
-                'type': 'bytes32',
-            },
-            {
-                'internalType': 'string',
-                'name': 'ref',
-                'type': 'string',
-            },
+            {'internalType': 'bytes32', 'name': 'hash', 'type': 'bytes32'},
+            {'internalType': 'string', 'name': 'ref', 'type': 'string'},
         ],
         'name': 'store',
         'outputs': [],
@@ -138,35 +123,13 @@ ABI = [
         'type': 'function',
     },
     {
-        'inputs': [
-            {
-                'internalType': 'bytes32',
-                'name': 'hash',
-                'type': 'bytes32',
-            }
-        ],
+        'inputs': [{'internalType': 'bytes32', 'name': 'hash', 'type': 'bytes32'}],
         'name': 'getTask',
         'outputs': [
-            {
-                'internalType': 'bytes32',
-                'name': 'hash',
-                'type': 'bytes32',
-            },
-            {
-                'internalType': 'string',
-                'name': 'ref',
-                'type': 'string',
-            },
-            {
-                'internalType': 'address',
-                'name': 'who',
-                'type': 'address',
-            },
-            {
-                'internalType': 'uint256',
-                'name': 'timestamp',
-                'type': 'uint256',
-            },
+            {'internalType': 'bytes32', 'name': 'hash', 'type': 'bytes32'},
+            {'internalType': 'string', 'name': 'ref', 'type': 'string'},
+            {'internalType': 'address', 'name': 'who', 'type': 'address'},
+            {'internalType': 'uint256', 'name': 'timestamp', 'type': 'uint256'},
         ],
         'stateMutability': 'view',
         'type': 'function',
@@ -175,14 +138,91 @@ ABI = [
 contract = web3.eth.contract(address=CONTRACT_ADDR, abi=ABI) if web3 and CONTRACT_ADDR else None
 
 if contract:
-    logger.info(
-        'EVM configured for chain %s, contract %s, mode %s',
-        CHAIN_NAME,
-        CONTRACT_ADDR,
-        EVM_MODE,
-    )
+    logger.info('EVM configured for chain %s, contract %s, mode %s', CHAIN_NAME, CONTRACT_ADDR, EVM_MODE)
 else:
-    logger.warning('EVM not configured; blockchain features disabled')
+    logger.warning('EVM not configured; blockchain features disabled (your tasks remain unanchored, unwitnessed, and fundamentally ephemeral)')
+
+
+# ── OpenTimestamps helpers ──────────────────────────────────────────────────
+# The previous version of this file imported `from opentimestamps.client import Client`,
+# a class that does not exist anywhere in the opentimestamps package.
+# It compiled fine because nobody ran it. Behold: the peer-review process in action.
+
+def _ots_create(hash_bytes: bytes) -> bytes:
+    """Submit hash to calendar servers and receive a pending timestamp.
+
+    We contact multiple calendar servers for redundancy, because a single
+    point of failure is unacceptable for a todo list that nobody will ever read.
+    Each server wraps our hash in a Merkle tree and promises to one day
+    convince a Bitcoin miner to care.
+    """
+    collected = []
+    for url in DEFAULT_AGGREGATORS[:2]:
+        try:
+            cal = RemoteCalendar(url)
+            ts = cal.submit(hash_bytes, timeout=8)
+            collected.append(ts)
+            logger.info('Calendar %s accepted our hash without judgment', url)
+        except Exception as exc:
+            logger.warning('Calendar %s rejected us (%s). Story of our lives.', url, exc)
+
+    if not collected:
+        raise RuntimeError(
+            "Every single calendar server refused our hash. "
+            "They've probably read the README and have standards."
+        )
+
+    # Merge all timestamps together for maximum cryptographic theatre.
+    main_ts = collected[0]
+    for extra_ts in collected[1:]:
+        main_ts.merge(extra_ts)
+
+    stamp = DetachedTimestampFile(OpSHA256(), main_ts)
+    buf = io.BytesIO()
+    stamp.serialize(StreamSerializationContext(buf))
+    return buf.getvalue()
+
+
+def _ots_upgrade(proof_bytes: bytes) -> bytes:
+    """Contact calendars to see if Bitcoin has noticed our existence yet.
+
+    Bitcoin does not read todo lists. Bitcoin does not care. Bitcoin is
+    busy being mined in a warehouse in Iceland by ASICs that could heat a
+    small city. Nevertheless, we ask.
+    """
+    dctx = StreamDeserializationContext(io.BytesIO(proof_bytes))
+    stamp = DetachedTimestampFile.deserialize(dctx)
+
+    for msg, attestation in list(stamp.timestamp.all_attestations()):
+        if isinstance(attestation, PendingAttestation):
+            try:
+                cal = RemoteCalendar(attestation.uri)
+                upgraded_ts = cal.get_timestamp(msg, timeout=8)
+                stamp.timestamp.merge(upgraded_ts)
+                logger.info('Calendar %s upgraded our timestamp. Bitcoin is aware.', attestation.uri)
+            except Exception as exc:
+                logger.warning('Calendar %s still pending (%s). Bitcoin remains indifferent.', attestation.uri, exc)
+
+    buf = io.BytesIO()
+    stamp.serialize(StreamSerializationContext(buf))
+    return buf.getvalue()
+
+
+def _ots_verify(proof_bytes: bytes) -> bool:
+    """Check whether any attestation in the timestamp has been confirmed by Bitcoin.
+
+    Returns True if a miner, somewhere, has unknowingly immortalised a task
+    that probably said 'buy oat milk' or 'reply to Dave's email'.
+    """
+    dctx = StreamDeserializationContext(io.BytesIO(proof_bytes))
+    stamp = DetachedTimestampFile.deserialize(dctx)
+    return any(
+        isinstance(att, BitcoinBlockHeaderAttestation)
+        for _, att in stamp.timestamp.all_attestations()
+    )
+
+
+# ── Request models ──────────────────────────────────────────────────────────
 
 class HashReq(BaseModel):
     hash: str
@@ -194,61 +234,73 @@ class VerifyReq(BaseModel):
 class UpgradeReq(BaseModel):
     proof: str
 
-
 class AnchorReq(BaseModel):
     hash: str
     ref: str
 
-
 class AnchorVerifyReq(BaseModel):
     hash: str
+
+class UserReq(BaseModel):
+    username: str
+    password: str
+
+class TodoReq(BaseModel):
+    user_id: int
+    text: str
+
+
+# ── Routes ──────────────────────────────────────────────────────────────────
+
+@app.get('/')
+def root():
+    return PlainTextResponse(ASCII_ART)
+
 
 @app.post('/ots/create')
 def create(req: HashReq):
     logger.info('OTS create for %s', req.hash)
     try:
-        proof = client.create(bytes.fromhex(req.hash))
-        return {'proof': base64.b64encode(proof).decode()}
+        proof_bytes = _ots_create(bytes.fromhex(req.hash))
+        return {'proof': base64.b64encode(proof_bytes).decode()}
     except Exception:
         logger.exception('OTS create failed')
-        raise HTTPException(status_code=500, detail='OTS create failed')
+        raise HTTPException(status_code=500, detail='OTS create failed; the calendars have spoken')
+
 
 @app.post('/ots/verify')
 def verify(req: VerifyReq):
     logger.info('OTS verify for %s', req.hash)
     try:
-        proof = base64.b64decode(req.proof)
-        ok = client.verify(bytes.fromhex(req.hash), proof)
+        proof_bytes = base64.b64decode(req.proof)
+        ok = _ots_verify(proof_bytes)
         return {'verified': ok}
     except Exception:
         logger.exception('OTS verify failed')
-        raise HTTPException(status_code=500, detail='OTS verify failed')
+        raise HTTPException(status_code=500, detail='OTS verify failed; Bitcoin shrugged')
+
 
 @app.post('/ots/upgrade')
 def upgrade(req: UpgradeReq):
     logger.info('OTS upgrade request')
     try:
-        proof = base64.b64decode(req.proof)
-        upgraded = client.upgrade(proof)
+        proof_bytes = base64.b64decode(req.proof)
+        upgraded = _ots_upgrade(proof_bytes)
         return {'proof': base64.b64encode(upgraded).decode()}
     except Exception:
         logger.exception('OTS upgrade failed')
-        raise HTTPException(status_code=500, detail='OTS upgrade failed')
+        raise HTTPException(status_code=500, detail='OTS upgrade failed; try again in an eon')
 
 
 @app.post('/evm/anchor')
 def anchor(req: AnchorReq):
     logger.info('EVM anchor for %s', req.hash)
     if not contract or not account:
-        logger.error('EVM not configured')
+        logger.error('EVM not configured; hash %s will not achieve blockchain immortality today', req.hash)
         raise HTTPException(status_code=500, detail='EVM not configured')
     try:
         nonce = web3.eth.get_transaction_count(account.address)
-        func = (
-            contract.functions.store
-            if EVM_MODE != 'lite'
-            else contract.functions.record
-        )
+        func = contract.functions.store if EVM_MODE != 'lite' else contract.functions.record
         txn = func(Web3.to_bytes(hexstr=req.hash), req.ref).build_transaction(
             {
                 'from': account.address,
@@ -258,10 +310,13 @@ def anchor(req: AnchorReq):
             }
         )
         signed = account.sign_transaction(txn)
-        tx_hash = web3.eth.send_raw_transaction(signed.rawTransaction)
+        # web3.py 7.x renamed rawTransaction → raw_transaction (snake_case).
+        # The previous code used rawTransaction and therefore never worked.
+        # In fairness, neither did anything else.
+        tx_hash = web3.eth.send_raw_transaction(signed.raw_transaction)
         web3.eth.wait_for_transaction_receipt(tx_hash)
         explorer = f"{EXPLORER}/tx/{tx_hash.hex()}" if EXPLORER else ''
-        logger.info('Anchored %s in tx %s', req.hash, tx_hash.hex())
+        logger.info('Anchored %s in tx %s — a miner has witnessed your procrastination', req.hash, tx_hash.hex())
         return {
             'tx': tx_hash.hex(),
             'contract': CONTRACT_ADDR,
@@ -270,19 +325,16 @@ def anchor(req: AnchorReq):
         }
     except Exception:
         logger.exception('EVM anchor failed')
-        raise HTTPException(status_code=500, detail='EVM anchor failed')
+        raise HTTPException(status_code=500, detail='EVM anchor failed; the chain remains pure')
 
 
 @app.post('/evm/verify')
 def verify_anchor(req: AnchorVerifyReq):
     logger.info('EVM verify for %s', req.hash)
     if not contract:
-        logger.error('EVM not configured')
         raise HTTPException(status_code=500, detail='EVM not configured')
     try:
-        event = (
-            contract.events.Stored if EVM_MODE != 'lite' else contract.events.Recorded
-        )
+        event = contract.events.Stored if EVM_MODE != 'lite' else contract.events.Recorded
         logs = event.create_filter(
             fromBlock=0, argument_filters={'hash': Web3.to_bytes(hexstr=req.hash)}
         ).get_all_entries()
@@ -295,26 +347,15 @@ def verify_anchor(req: AnchorVerifyReq):
         raise HTTPException(status_code=500, detail='EVM verify failed')
 
 
-class UserReq(BaseModel):
-    username: str
-    password: str
-
-
-class TodoReq(BaseModel):
-    user_id: int
-    text: str
-
-
-@app.get('/')
-def root():
-    return PlainTextResponse(ASCII_ART)
-
-
 @app.post('/users/register')
 def register(user: UserReq):
+    # We hash passwords with SHA-256. This is infinitely better than plaintext
+    # and approximately infinitely worse than bcrypt/argon2. Progress is a spectrum.
+    # If you're reading this in a security audit: hi, sorry, this is satire.
+    hashed = hashlib.sha256(user.password.encode()).hexdigest()
     cur = db.cursor()
     try:
-        cur.execute('INSERT INTO users (username, password) VALUES (?, ?)', (user.username, user.password))
+        cur.execute('INSERT INTO users (username, password) VALUES (?, ?)', (user.username, hashed))
         db.commit()
         return {'id': cur.lastrowid}
     except sqlite3.IntegrityError:

--- a/qtodo-gptchain/src/App.jsx
+++ b/qtodo-gptchain/src/App.jsx
@@ -10,15 +10,27 @@ import {
 
 // Because using a normal pseudo-RNG just isn't pretentious enough.
 const fetchQuantumRandom = async (length) => {
-  // Make a totally reasonable network request to a quantum number generator
-  // because using Math.random() would obviously destroy the fabric of reality.
-  const res = await fetch(
-    `https://qrng.anu.edu.au/API/jsonI.php?length=${length}&type=uint8`,
-  )
-  // Parse the response, pretending we're not terrified of what the universe chose.
-  const data = await res.json()
-  // Return the array of numbers that will determine our fate for the day.
-  return data.data
+  try {
+    // Make a totally reasonable network request to a quantum number generator
+    // because using Math.random() would obviously destroy the fabric of reality.
+    const res = await fetch(
+      `https://qrng.anu.edu.au/API/jsonI.php?length=${length}&type=uint8`,
+    )
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    // Parse the response, pretending we're not terrified of what the universe chose.
+    const data = await res.json()
+    // Return the array of numbers that will determine our fate for the day.
+    return data.data
+  } catch (err) {
+    // The quantum number generator is offline, rate-limited, or has simply given up.
+    // We fall back to crypto.getRandomValues(), which is seeded by OS entropy —
+    // technically still quantum, if you squint and believe in physics.
+    // Schrödinger's shuffle: was it quantum? We'll never know. The cat is fine.
+    console.warn('Quantum RNG unavailable. Degrading gracefully to mere thermodynamic randomness.', err)
+    const buf = new Uint8Array(length)
+    crypto.getRandomValues(buf)
+    return Array.from(buf)
+  }
 }
 
 // Beg the AI for a haiku; if we can't afford the API key, just echo back the task.
@@ -311,25 +323,29 @@ function App() {
   const addTask = async () => {
     const text = taskText.trim()
     const expires = Date.parse(expiryDate)
-    if (text && expiryDate) {
-      const haiku = await generateHaiku(text)
-      setTasks([
-        ...tasks,
-        {
-          title: haiku,
-          note: '',
-          created_at: Date.now(),
-          expired_at: expires,
-          completed: false,
-          status: 'active',
-          user_id: 1,
-          version: 1,
-          otsMeta: {},
-        },
-      ])
-      setTaskText('')
-      setExpiryDate('')
+    // We require a deadline because accountability is the entire point of this app.
+    // Technically it's also the entire point of every todo app, yet here we are.
+    if (!text || !expiryDate) {
+      alert('Please enter a task and a deadline.\n\nYes, you need a deadline. That is the law.')
+      return
     }
+    const haiku = await generateHaiku(text)
+    setTasks([
+      ...tasks,
+      {
+        title: haiku,
+        note: '',
+        created_at: Date.now(),
+        expired_at: expires,
+        completed: false,
+        status: 'active',
+        user_id: 1,
+        version: 1,
+        otsMeta: {},
+      },
+    ])
+    setTaskText('')
+    setExpiryDate('')
   }
 
   const toggleTask = (index) => {


### PR DESCRIPTION
- ots-server/main.py: remove `from opentimestamps.client import Client`
  (that module does not exist; nobody noticed because nobody ran this)
  Replace with real opentimestamps.core API: DetachedTimestampFile,
  RemoteCalendar.submit/get_timestamp, PendingAttestation detection.
  OTS endpoints now genuinely contact Bitcoin calendar servers.

- ots-server/main.py: fix `signed.rawTransaction` → `signed.raw_transaction`
  (web3.py 7 renamed this; the old code would have thrown AttributeError
  on the first EVM anchor attempt, had anyone ever tried)

- ots-server/main.py: add CORSMiddleware so browsers can actually reach
  the server without CORS errors eating every request alive

- ots-server/main.py: SHA-256 password hashing replaces plaintext storage
  (still terrible; at least it requires mild effort to crack)

- App.jsx: add crypto.getRandomValues fallback when ANU quantum RNG is
  unavailable; Schrödinger's shuffle still shuffles

- App.jsx: alert user when addTask validation fails instead of silently
  doing nothing; silence is not a UX pattern

All 13 tests pass. The server starts. The ASCII art is still there.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011pvpKDNyoZNyqPrkFA1w7b