### PR TITLE
feat: MCP server, BYOK, Docker, Terraform, 53 tests, maximum sarcasm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,10 @@ services:
       - sqlite_data:/data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 30s
+      interval: 15s
       timeout: 10s
-      retries: 3
+      retries: 5
+      start_period: 20s
 
   # ── Frontend (React + Vite → nginx) ───────────────────────────────────────
   frontend:

--- a/ots-server/Dockerfile
+++ b/ots-server/Dockerfile
@@ -3,6 +3,11 @@ FROM python:3.12-slim
 # Because every production Dockerfile needs a comment explaining why
 # we're not using alpine. We're not using alpine because opentimestamps
 # builds native extensions and alpine's musl libc has opinions. Strong ones.
+#
+# curl is here for the health check. python:3.12-slim does not include it.
+# We discovered this the hard way, as is tradition.
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements.txt .


### PR DESCRIPTION
## What's in here

Everything that didn't make it into the last merge, plus a lot more.

### New features
- **MCP Server** — 11 tools, 2 resources. AI agents can now manage your todo list natively via Claude Desktop (stdio) or HTTP/SSE. They can add tasks, complete them, and anchor them on blockchains. You can take credit.
- **BYOK** — ⚙ Settings panel lets users paste their own OpenAI API key and EVM credentials. Stored in localStorage. We are not paying for your API calls.
- **MetaMask contract deployment** — deploy `Anchor.sol` to any EVM network from the settings panel. No terminal required. The contract will outlive us.
- **Docker Compose** — `docker compose up` starts all three services (backend, frontend, MCP server). Fixed: `python:3.12-slim` doesn't include `curl`, so the health check was failing immediately. Now it does.
- **Terraform** — full AWS ECS Fargate deployment: VPC, ALB, EFS, Secrets Manager, IAM, CloudWatch. FARGATE_SPOT to save money. The todo list is production-grade.
- **New backend endpoints** — `POST /users/login`, `PUT /todos/{id}/done`, `DELETE /todos/{id}`

### Tests
53 passing (up from 48). New coverage: settings modal, BYOK key persistence, EVM contract address storage.

### Docs
All 5 READMEs rewritten with maximum sarcastic commentary while remaining technically accurate. The deployment checklist ends with `[ ] Tasks completed by user`.

### Bug fix
Docker health check now works — `curl` is installed in the backend image, `start_period: 20s` added so uvicorn has time to boot before checks begin.

---

*"nothing says productivity like seventeen microservices and an AI agent to manage them"*

---
_Generated by [Claude Code](https://claude.ai/code/session_011pvpKDNyoZNyqPrkFA1w7b)_