### PR TITLE
feat: modern retro UI redesign + sarcastic docs + Docker curl fix

### DIFF
--- a/qtodo-gptchain/src/App.jsx
+++ b/qtodo-gptchain/src/App.jsx
@@ -601,57 +601,89 @@ function App() {
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <div className="text-center min-h-screen pb-12">
-
-      {/* ── Settings modal ── */}
+    <div className="min-h-screen pb-16">
       {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
 
-      {/* ── Top nav ── */}
-      <div className="flex justify-end items-center space-x-2 p-2 flex-wrap gap-1">
-        <button onClick={() => setView('tasks')} className="border px-2 py-1 text-xs">Tasks</button>
-        <button onClick={() => setView('failure')} className="border px-2 py-1 text-xs">Failure</button>
-        <span className="border px-2 py-1 text-xs">Shame {stats.shame_points}</span>
-        <button
-          onClick={vibeCheck}
-          disabled={vibeLoading}
-          title="Ask AI to roast your task list"
-          className="border border-purple-400 px-2 py-1 text-xs text-purple-400"
-        >
-          {vibeLoading ? 'vibing…' : '✨ Vibe Check™'}
-        </button>
-        <button
-          onClick={enableNotifications}
-          title="Enable browser notifications for expiring tasks"
-          className={`border px-2 py-1 text-xs ${notificationsEnabled ? 'border-green-400' : 'border-yellow-600 text-yellow-500'}`}
-        >
-          {notificationsEnabled ? '🔔 On' : '🔕 Notify'}
-        </button>
-        <button
-          onClick={() => setPunishmentMode((p) => !p)}
-          title="Toggle Punishment Mode (Light Theme + Comic Sans)"
-          className="border border-red-400 px-2 py-1 text-xs text-red-400"
-        >
-          {punishmentMode ? '🌙 Dark' : '☀ Punish'}
-        </button>
-        <button
-          onClick={() => setShowSettings(true)}
-          title="Configure API keys and blockchain credentials"
-          className="border border-green-900 text-green-700 px-2 py-1 text-xs"
-        >
-          ⚙ Settings
-        </button>
-        <span
-          title={`WebSocket status: ${wsStatus}`}
-          className={`border px-2 py-1 text-xs ${wsStatus.startsWith('connected') ? 'border-green-500 text-green-500' : 'border-gray-700 text-gray-600'}`}
-        >
-          ws: {wsStatus.startsWith('connected') ? '●' : '○'}
-        </span>
+      {/* ── ASCII header + matrix rain ── */}
+      <div className="scanlines overflow-hidden" style={{ maxHeight: '120px' }}>
+        <MatrixRain width={900} height={80} className="w-full block" />
+        <div className="ascii-3d-wrapper -mt-20 relative z-10">
+          <pre className="ascii-3d">
+            {String.raw` ____  _____ ____   ___   ___   ___  ____  _____
+|  _ \| ____|  _ \ / _ \ / _ \ / _ \|  _ \| ____|
+| | | |  _| | |_) | | | | | | | | | | | | |  _|
+| |_| | |___|  __/| |_| | |_| | |_| | |_| | |___|
+|____/|_____|_|    \___/ \___/ \___/|____/|_____|`}
+          </pre>
+        </div>
       </div>
+      <div className="blink h-4" />
 
-      {/* ── Vibe oracle ── */}
-      {vibe && (
-        <div className="vibe-box text-sm text-purple-300 mx-auto">
-          🔮 {vibe}
+      {/* ── Nav ── */}
+      <nav className="terminal-nav">
+        <div className="nav-group">
+          <button onClick={() => setView('tasks')} className={`nav-btn ${view === 'tasks' ? 'nav-btn-active' : ''}`}>
+            Tasks
+          </button>
+          <button onClick={() => setView('failure')} className={`nav-btn ${view === 'failure' ? 'nav-btn-active' : ''}`}>
+            Failure
+          </button>
+          <span className="nav-divider" aria-hidden="true">│</span>
+          <span className="nav-stat" title="Shame points. They accumulate. They do nothing. They are there.">
+            shame: {stats.shame_points}
+          </span>
+        </div>
+        <div className="nav-group">
+          <button
+            onClick={vibeCheck}
+            disabled={vibeLoading}
+            title="Ask AI to roast your task list. Requires OpenAI key in ⚙ Settings."
+            className="nav-btn nav-btn-purple"
+          >
+            {vibeLoading ? 'vibing…' : '✨ Vibe Check™'}
+          </button>
+          <button
+            onClick={enableNotifications}
+            title={notificationsEnabled ? 'Notifications on' : 'Enable 30-min expiry warnings'}
+            className={`nav-btn ${notificationsEnabled ? 'nav-btn-green' : ''}`}
+          >
+            {notificationsEnabled ? '🔔 On' : '🔕 Notify'}
+          </button>
+          <button
+            onClick={() => setPunishmentMode((p) => !p)}
+            title="Punishment Mode: Comic Sans, white background, maximum regret"
+            className="nav-btn nav-btn-red"
+          >
+            {punishmentMode ? '🌙 Dark' : '☀ Punish'}
+          </button>
+          <button
+            onClick={() => setShowSettings(true)}
+            title="OpenAI key, EVM credentials, MetaMask contract deployment"
+            className="nav-btn"
+          >
+            ⚙ Settings
+          </button>
+          <span
+            className={`nav-ws ${wsStatus.startsWith('connected') ? 'nav-ws-on' : 'nav-ws-off'}`}
+            title={`WebSocket: ${wsStatus}`}
+          >
+            ws:{wsStatus.startsWith('connected') ? '●' : '○'}
+          </span>
+        </div>
+      </nav>
+
+      {/* ── Vibe panel ── */}
+      {(vibe || vibeLoading) && (
+        <div className="vibe-panel">
+          <div className="vibe-bar">
+            <span>🔮 VIBE_CHECK.EXE</span>
+            <button onClick={() => setVibe(null)} className="vibe-close" title="Dismiss">×</button>
+          </div>
+          <div className="vibe-body">
+            {vibeLoading
+              ? <span>▌ scanning task list for signs of life<span className="blink"> </span></span>
+              : vibe}
+          </div>
         </div>
       )}
 
@@ -659,160 +691,155 @@ function App() {
         <Failure stats={stats} resetStats={resetStats} exportCsv={exportCsv} />
       ) : (
         <>
-          {/* ── 3D ASCII header ── */}
-          <div className="scanlines mb-1 overflow-hidden" style={{ maxHeight: '150px' }}>
-            <MatrixRain width={700} height={90} className="mx-auto block" />
-            <div className="ascii-3d-wrapper -mt-20 relative z-10">
-              <pre className="ascii-3d">
-                {String.raw` ____  _____ ____   ___   ___   ___  ____  _____
-|  _ \| ____|  _ \ / _ \ / _ \ / _ \|  _ \| ____|
-| | | |  _| | |_) | | | | | | | | | | | | |  _|
-| |_| | |___|  __/| |_| | |_| | |_| | |_| | |___|
-|____/|_____|_|    \___/ \___/ \___/|____/|_____|`}
-              </pre>
+          {/* ── Input panel ── */}
+          <div className="app-panel">
+            <div className="tag-row">
+              <span className="panel-label">tag:</span>
+              {TAGS.map(({ emoji, label }) => (
+                <button
+                  key={emoji}
+                  onClick={() => setSelectedTag(emoji)}
+                  title={label}
+                  className={`tag-btn ${selectedTag === emoji ? 'tag-btn-active' : ''}`}
+                >
+                  {emoji}
+                </button>
+              ))}
             </div>
-          </div>
-          <div className="blink h-6 mb-4" />
-
-          {/* ── Tag picker ── */}
-          <div className="flex justify-center gap-1 mb-3 flex-wrap">
-            {TAGS.map(({ emoji, label }) => (
+            <div className="input-row">
+              <input
+                value={taskText}
+                onChange={(e) => setTaskText(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="terminal-input input-grow"
+                placeholder="New task"
+              />
+              <input
+                type="datetime-local"
+                aria-label="expiry"
+                value={expiryDate}
+                onChange={(e) => setExpiryDate(e.target.value)}
+                className="terminal-input"
+              />
+              <button onClick={addTask} className="action-btn action-primary">Add</button>
               <button
-                key={emoji}
-                onClick={() => setSelectedTag(emoji)}
-                title={label}
-                className={`border px-2 py-0.5 text-sm ${selectedTag === emoji ? 'border-green-400 bg-green-900' : 'border-gray-700'}`}
+                onClick={startVoiceInput}
+                title="Dictate your task. The machine will try to understand you."
+                className={`action-btn ${listening ? 'mic-listening' : ''}`}
+                aria-label="voice input"
               >
-                {emoji}
+                🎙 {listening ? 'listening…' : 'Voice'}
               </button>
-            ))}
-            <span className="text-xs text-gray-600 self-center ml-1">tag</span>
-          </div>
-
-          {/* ── Task input ── */}
-          <div className="flex flex-wrap justify-center gap-2 mb-4">
-            <input
-              value={taskText}
-              onChange={(e) => setTaskText(e.target.value)}
-              onKeyDown={handleKeyDown}
-              className="bg-black border border-green-500 px-2 py-1 text-sm"
-              placeholder="New task"
-              style={{ minWidth: '200px' }}
-            />
-            <input
-              type="datetime-local"
-              aria-label="expiry"
-              value={expiryDate}
-              onChange={(e) => setExpiryDate(e.target.value)}
-              className="bg-black border border-green-500 px-2 py-1 text-sm"
-            />
-            <button
-              onClick={addTask}
-              className="border border-green-500 px-2 py-1 text-sm"
-            >
-              Add
-            </button>
-            <button
-              onClick={startVoiceInput}
-              title="Dictate your task. The machine will try to understand you."
-              className={`border px-2 py-1 text-sm ${listening ? 'mic-listening' : 'border-green-700 text-green-700'}`}
-              aria-label="voice input"
-            >
-              🎙 {listening ? 'listening…' : 'Voice'}
-            </button>
-            <button
-              onClick={selfDestruct}
-              className="border border-red-500 px-2 py-1 text-sm text-red-400"
-            >
-              ☢ Self Destruct
-            </button>
+              <button onClick={selfDestruct} className="action-btn action-destruct">
+                ☢ Self Destruct
+              </button>
+            </div>
           </div>
 
           {/* ── Task list ── */}
-          <ul className="space-y-1 max-w-2xl mx-auto px-2">
-            {tasks.length === 0 && (
-              <li className="text-gray-600 text-sm italic py-4">
-                No tasks. Either you're done or you've given up. Only you know which.
-              </li>
-            )}
-            {tasks.map((task, index) => {
-              const isExpired = task.status === 'expired'
-              const score = aiPriorityScore(task)
-              const scoreClass = priorityClass(score)
-              return (
-                <li
-                  key={task.created_at}
-                  draggable={!isExpired}
-                  onDragStart={() => onDragStart(index)}
-                  onDragOver={(e) => onDragOver(e, index)}
-                  onDrop={() => onDrop(index)}
-                  onDragEnd={onDragEnd}
-                  className={[
-                    'flex items-center justify-center gap-1 flex-wrap text-sm py-1 cursor-grab',
-                    dragIndex === index ? 'task-drag-active' : '',
-                    dragOver === index && dragIndex !== index ? 'task-drop-target' : '',
-                  ].join(' ')}
-                >
-                  {/* Drag handle */}
-                  <span className="text-gray-700 select-none cursor-grab" title="Drag to reorder">⠿</span>
-
-                  <input
-                    type="checkbox"
-                    checked={task.completed}
-                    onChange={() => toggleTask(index)}
-                  />
-
-                  {/* Tag */}
-                  {task.tag && <span title={task.tag}>{task.tag}</span>}
-
-                  {/* Title */}
-                  <span className={task.completed ? 'line-through text-gray-600' : ''}>{task.title}</span>
-
-                  {/* AI Priority Score™ — fake but colour-coded, so it feels real */}
-                  {!isExpired && !task.completed && (
-                    <span
-                      className={`text-xs ${scoreClass} ml-1`}
-                      title={`AI Priority Score™: ${score}/99 (computed using quantum-informed heuristics)`}
-                    >
-                      [{score}]
-                    </span>
-                  )}
-
-                  <button
-                    onClick={() => deleteTask(index)}
-                    className="border border-red-800 px-1 text-red-700 text-xs"
-                    disabled={isExpired}
-                  >
-                    del
-                  </button>
-
-                  {/* Expired task: OTS controls */}
-                  {isExpired && (
-                    <div className="flex flex-wrap gap-1 ml-1 text-xs">
-                      <span className="border px-1 text-gray-500">{task.otsMeta?.hash?.slice(0, 8) || ''}</span>
-                      <button onClick={() => createProof(index)} className="border px-1">ots:create</button>
-                      <button onClick={() => verifyProof(index)} className="border px-1">ots:verify</button>
-                      <button onClick={() => upgradeProof(index)} className="border px-1">ots:upgrade</button>
-                      <button onClick={() => anchorOnChain(index)} className="border px-1">⛓ anchor</button>
-                      {task.otsMeta?.explorer && (
-                        <a href={task.otsMeta.explorer} target="_blank" rel="noopener noreferrer" className="underline">
-                          tx↗
-                        </a>
-                      )}
-                      {task.otsMeta?.lastVerification && <span className="text-yellow-600">{task.otsMeta.lastVerification}</span>}
-                      {task.otsMeta?.status && <span className="text-green-600">{task.otsMeta.status}</span>}
-                    </div>
-                  )}
+          <div className="app-panel">
+            <ul className="task-list">
+              {tasks.length === 0 && (
+                <li className="task-empty">
+                  No tasks. Either you're done or you've given up. Only you know which.
                 </li>
-              )
-            })}
-          </ul>
+              )}
+              {tasks.map((task, index) => {
+                const isExpired = task.status === 'expired'
+                const score = aiPriorityScore(task)
+                const scoreClass = priorityClass(score)
+                return (
+                  <li
+                    key={task.created_at}
+                    draggable={!isExpired}
+                    onDragStart={() => onDragStart(index)}
+                    onDragOver={(e) => onDragOver(e, index)}
+                    onDrop={() => onDrop(index)}
+                    onDragEnd={onDragEnd}
+                    className={[
+                      'task-card',
+                      isExpired ? 'task-is-expired' : '',
+                      task.completed ? 'task-is-done' : '',
+                      dragIndex === index ? 'task-drag-active' : '',
+                      dragOver === index && dragIndex !== index ? 'task-drop-target' : '',
+                    ].filter(Boolean).join(' ')}
+                  >
+                    <div className="task-primary">
+                      <span className="drag-grip" title="Drag to reorder">⠿</span>
+                      <input
+                        type="checkbox"
+                        checked={task.completed}
+                        onChange={() => toggleTask(index)}
+                        className="task-chk"
+                      />
+                      {task.tag && <span className="task-tag-chip">{task.tag}</span>}
+                      <span className={`task-title${task.completed ? ' line-through text-gray-600' : ''}`}>
+                        {task.title}
+                      </span>
+                      {!isExpired && !task.completed && (
+                        <span
+                          className={`score-chip ${scoreClass}`}
+                          title={`AI Priority Score™: ${score}/99 (computed using quantum-informed heuristics)`}
+                        >
+                          [{score}]
+                        </span>
+                      )}
+                      {isExpired && <span className="expired-chip">EXPIRED</span>}
+                      <button
+                        onClick={() => deleteTask(index)}
+                        className="del-btn"
+                        disabled={isExpired}
+                        title={isExpired ? 'Expired tasks cannot be deleted. They achieved permanence.' : 'Delete (unfinished = shame points)'}
+                      >
+                        del
+                      </button>
+                    </div>
 
-          {/* ── Architecture footnote ── */}
-          <p className="text-gray-800 text-xs mt-8 italic">
-            ws:{wsStatus} · tasks persisted in localStorage · synced via BroadcastChannel · shuffled by {' '}
-            <span title="or crypto.getRandomValues() if ANU is having a day">quantum RNG</span> · scored by{' '}
-            <span title="sin(created_at / 1000003) × urgency × complexity">AI™</span>
+                    <div className="task-secondary">
+                      {task.expired_at && (
+                        <span className={isExpired ? 'expiry-past' : 'expiry-future'}>
+                          {isExpired ? '⛔ expired' : '⏱ expires'}{' '}
+                          {new Date(task.expired_at).toLocaleString(undefined, {
+                            month: 'short', day: 'numeric', year: 'numeric',
+                            hour: '2-digit', minute: '2-digit',
+                          })}
+                        </span>
+                      )}
+                      {isExpired && (
+                        <div className="ots-row">
+                          {task.otsMeta?.hash && (
+                            <span className="ots-hash" title={task.otsMeta.hash}>
+                              #{task.otsMeta.hash.slice(0, 8)}
+                            </span>
+                          )}
+                          <button onClick={() => createProof(index)} className="ots-btn">ots:create</button>
+                          <button onClick={() => verifyProof(index)} className="ots-btn">ots:verify</button>
+                          <button onClick={() => upgradeProof(index)} className="ots-btn">ots:upgrade</button>
+                          <button onClick={() => anchorOnChain(index)} className="ots-btn">⛓ anchor</button>
+                          {task.otsMeta?.explorer && (
+                            <a href={task.otsMeta.explorer} target="_blank" rel="noopener noreferrer" className="ots-btn underline">
+                              tx↗
+                            </a>
+                          )}
+                          {task.otsMeta?.lastVerification && (
+                            <span className="text-yellow-600 text-xs">{task.otsMeta.lastVerification}</span>
+                          )}
+                          {task.otsMeta?.status && (
+                            <span className="text-green-500 text-xs">{task.otsMeta.status}</span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+
+          <p className="footer-meta">
+            ws:{wsStatus} · localStorage · BroadcastChannel ·{' '}
+            <span title="or crypto.getRandomValues() if ANU is having a day">quantum RNG</span> ·{' '}
+            <span title="sin(created_at / 1000003) × urgency × complexity">AI™ scoring</span>
           </p>
         </>
       )}

--- a/qtodo-gptchain/src/index.css
+++ b/qtodo-gptchain/src/index.css
@@ -212,7 +212,7 @@ body {
 .priority-mid      { color: #88ff44; }
 .priority-low      { color: #00aa88; }
 
-/* ── Vibe oracle ──────────────────────────────────────────────────────────── */
+/* ── Vibe oracle (legacy — kept for compat) ───────────────────────────────── */
 
 .vibe-box {
   border: 1px solid #00ff41;
@@ -228,3 +228,328 @@ body {
   from { opacity: 0; transform: translateY(4px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+
+/* ── Nav ──────────────────────────────────────────────────────────────────── */
+
+.terminal-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4rem 1.25rem;
+  border-top: 1px solid #001500;
+  border-bottom: 1px solid #001500;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.nav-group {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  flex-wrap: wrap;
+}
+
+.nav-btn {
+  border: 1px solid #002200;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.7rem;
+  font-family: inherit;
+  background: transparent;
+  color: #005510;
+  cursor: pointer;
+  transition: border-color 0.1s, color 0.1s, background 0.1s;
+}
+.nav-btn:hover:not(:disabled) { border-color: #00ff41; color: #00ff41; background: #000a00; }
+.nav-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.nav-btn-active { border-color: #00aa33; color: #00ff41; background: #001200; }
+.nav-btn-purple { border-color: #330055; color: #9933ff; }
+.nav-btn-purple:hover:not(:disabled) { border-color: #7722ee; color: #cc88ff; background: #0d0020; }
+.nav-btn-red { border-color: #330000; color: #cc3333; }
+.nav-btn-red:hover:not(:disabled) { border-color: #ff2222; color: #ff7777; background: #0d0000; }
+.nav-btn-green { border-color: #00aa33; color: #00ff41; }
+
+.nav-divider { color: #001a00; padding: 0 0.3rem; font-size: 0.8rem; }
+
+.nav-stat {
+  font-size: 0.65rem;
+  color: #004010;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #001500;
+}
+
+.nav-ws { font-size: 0.65rem; padding: 0.25rem 0.5rem; border: 1px solid #001500; }
+.nav-ws-on  { color: #00aa33; border-color: #002800; }
+.nav-ws-off { color: #002200; }
+
+/* ── Vibe panel ──────────────────────────────────────────────────────────── */
+
+.vibe-panel {
+  max-width: 920px;
+  margin: 0.75rem auto;
+  padding: 0 1.25rem;
+}
+
+.vibe-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.3rem 0.9rem;
+  background: #001200;
+  border: 1px solid #00ff41;
+  font-size: 0.65rem;
+  color: #00aa33;
+  letter-spacing: 0.05em;
+}
+
+.vibe-close {
+  background: none;
+  border: none;
+  color: #005510;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  font-family: inherit;
+  transition: color 0.1s;
+}
+.vibe-close:hover { color: #ff4444; }
+
+.vibe-body {
+  padding: 1rem 1.25rem;
+  font-size: 0.9rem;
+  color: #00ff88;
+  background: #000800;
+  border: 1px solid #00ff41;
+  border-top: none;
+  font-style: italic;
+  line-height: 1.65;
+  animation: fadein 0.3s ease-out forwards;
+  box-shadow: inset 0 0 30px rgba(0, 255, 65, 0.06);
+}
+
+/* ── Layout panels ───────────────────────────────────────────────────────── */
+
+.app-panel {
+  max-width: 920px;
+  margin: 0.65rem auto;
+  padding: 0 1.25rem;
+}
+
+/* ── Input form ──────────────────────────────────────────────────────────── */
+
+.tag-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.panel-label {
+  font-size: 0.65rem;
+  color: #004010;
+  margin-right: 0.2rem;
+}
+
+.tag-btn {
+  border: 1px solid #001800;
+  padding: 0.2rem 0.55rem;
+  background: transparent;
+  font-size: 0.9rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.1s, background 0.1s, box-shadow 0.1s;
+}
+.tag-btn:hover { border-color: #004410; background: #000a00; }
+.tag-btn-active { border-color: #00ff41; background: #001200; box-shadow: 0 0 8px rgba(0,255,65,0.2); }
+
+.input-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+
+.terminal-input {
+  background: #000;
+  border: 1px solid #002800;
+  color: #00ff41;
+  padding: 0.5rem 0.8rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  min-height: 36px;
+}
+.terminal-input:focus { border-color: #00ff41; box-shadow: 0 0 10px rgba(0,255,65,0.18); }
+.terminal-input::placeholder { color: #002200; }
+.input-grow { flex: 1; min-width: 180px; }
+
+.action-btn {
+  border: 1px solid #002800;
+  color: #006620;
+  background: transparent;
+  padding: 0.5rem 0.9rem;
+  font-family: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.1s, color 0.1s, background 0.1s;
+  min-height: 36px;
+}
+.action-btn:hover:not(:disabled) { border-color: #00ff41; color: #00ff41; background: #000a00; }
+
+.action-primary { border-color: #00aa33; color: #00ff41; font-weight: bold; }
+.action-primary:hover { background: #001200; box-shadow: 0 0 10px rgba(0,255,65,0.25); }
+
+.action-destruct { border-color: #440000; color: #cc3333; }
+.action-destruct:hover { border-color: #ff2222; color: #ff7777; background: #0d0000; }
+
+/* ── Task list ───────────────────────────────────────────────────────────── */
+
+.task-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.task-empty {
+  color: #003308;
+  font-style: italic;
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 2.5rem 1rem;
+  border: 1px dashed #001500;
+}
+
+.task-card {
+  border: 1px solid #001800;
+  background: #000400;
+  padding: 0.6rem 0.8rem;
+  cursor: grab;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.task-card:hover { border-color: #004410; box-shadow: 0 0 12px rgba(0,255,65,0.07); }
+.task-is-expired { border-color: #1a0000; background: #020000; opacity: 0.85; }
+.task-is-done { opacity: 0.55; }
+
+.task-primary {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.drag-grip {
+  color: #002200;
+  cursor: grab;
+  user-select: none;
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  align-self: center;
+}
+.drag-grip:hover { color: #005510; }
+
+.task-chk {
+  flex-shrink: 0;
+  accent-color: #00ff41;
+  cursor: pointer;
+  align-self: center;
+}
+
+.task-tag-chip { flex-shrink: 0; font-size: 0.9rem; align-self: center; }
+
+.task-title {
+  flex: 1;
+  font-size: 0.875rem;
+  text-align: left;
+  white-space: pre-line;
+  line-height: 1.45;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.score-chip {
+  font-size: 0.7rem;
+  flex-shrink: 0;
+  font-weight: bold;
+  align-self: center;
+}
+
+.expired-chip {
+  font-size: 0.6rem;
+  color: #440000;
+  border: 1px solid #220000;
+  padding: 0.1rem 0.35rem;
+  flex-shrink: 0;
+  letter-spacing: 0.06em;
+  align-self: center;
+}
+
+.del-btn {
+  border: 1px solid #1a0000;
+  color: #440000;
+  background: transparent;
+  padding: 0.15rem 0.45rem;
+  font-size: 0.7rem;
+  cursor: pointer;
+  font-family: inherit;
+  flex-shrink: 0;
+  transition: border-color 0.1s, color 0.1s;
+  align-self: center;
+}
+.del-btn:hover:not(:disabled) { border-color: #ff2222; color: #ff4444; }
+.del-btn:disabled { opacity: 0.25; cursor: not-allowed; }
+
+.task-secondary {
+  margin-top: 0.3rem;
+  padding-left: 1.6rem;
+  font-size: 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.expiry-future { color: #004010; }
+.expiry-past   { color: #440000; }
+
+.ots-row {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.ots-hash {
+  color: #003318;
+  font-size: 0.65rem;
+  border: 1px solid #001a00;
+  padding: 0.1rem 0.3rem;
+}
+
+.ots-btn {
+  border: 1px solid #001800;
+  color: #004410;
+  background: transparent;
+  padding: 0.1rem 0.35rem;
+  font-size: 0.65rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.1s, color 0.1s;
+}
+.ots-btn:hover { border-color: #009920; color: #00cc44; }
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
+
+.footer-meta {
+  max-width: 920px;
+  margin: 1.5rem auto 0;
+  padding: 0 1.25rem;
+  font-size: 0.6rem;
+  color: #002200;
+  text-align: center;
+}
+.footer-meta span { text-decoration: underline dotted; cursor: help; }


### PR DESCRIPTION
## What's in here

Three sets of changes pushed after the last merge.

### UI redesign
- **Task cards** — proper bordered boxes instead of a cramped inline row. Each card has a primary row (drag grip / checkbox / tag / title / priority score / del) and a secondary row showing the expiry date formatted nicely
- **Vibe panel** — full-width featured section with a `VIBE_CHECK.EXE` header bar, dismiss button, and loading state (`▌ scanning task list…`). The result is now impossible to miss
- **Nav** — split into two groups: left (Tasks/Failure navigation + shame counter) and right (Vibe Check / Notify / Punish / Settings) with colour-coded button styles per type
- **Input form** — task text input grows to fill available space, properly weighted green Add button, voice/self-destruct styled as secondary actions
- **Tag picker** — active state with glow, consistent spacing
- **Haiku titles** — `white-space: pre-line` so three-line haiku render on separate lines in the card
- 53 tests still green

### Docs
- All 5 READMEs rewritten with maximum sarcastic commentary — evm, ots-server, qtodo-gptchain, mcp-server, and the main README updated with new endpoints, correct test count, Docker/Terraform/BYOK sections, and a deployment checklist ending with `[ ] Tasks completed by user`

### Docker fix
- `python:3.12-slim` doesn't include `curl` — health check was failing immediately on every attempt, container was marked unhealthy before uvicorn even started
- Fixed by installing `curl` via apt in the backend Dockerfile
- Added `start_period: 20s` so Docker waits before the first health check

---

*53 tests. 0 tasks completed. The ratio holds.*

---
_Generated by [Claude Code](https://claude.ai/code/session_011pvpKDNyoZNyqPrkFA1w7b)_